### PR TITLE
Add special extractor for yle.fi URLs in video downloader

### DIFF
--- a/pkg/utils/video_downloader_test.go
+++ b/pkg/utils/video_downloader_test.go
@@ -1,0 +1,145 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestIsYleFiURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "root yle.fi",
+			url:      "https://yle.fi/areena",
+			expected: true,
+		},
+		{
+			name:     "subdomain yle.fi",
+			url:      "https://areena.yle.fi/video/123",
+			expected: true,
+		},
+		{
+			name:     "another subdomain",
+			url:      "https://www.yle.fi/news",
+			expected: true,
+		},
+		{
+			name:     "non-yle.fi domain",
+			url:      "https://youtube.com/watch?v=123",
+			expected: false,
+		},
+		{
+			name:     "invalid URL",
+			url:      "not-a-url",
+			expected: false,
+		},
+		{
+			name:     "yle.fi in path but not domain",
+			url:      "https://example.com/yle.fi",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isYleFiURL(tt.url)
+			if result != tt.expected {
+				t.Errorf("isYleFiURL(%q) = %v, expected %v", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetSpecialExtractor(t *testing.T) {
+	yleDlAvailable := isCommandAvailable("yle-dl")
+
+	tests := []struct {
+		name          string
+		url           string
+		expectedCmd   string
+		expectedEmpty bool
+		requiresYleDl bool
+	}{
+		{
+			name:          "yle.fi URL with yle-dl available",
+			url:           "https://areena.yle.fi/video/123",
+			expectedCmd:   "yle-dl",
+			expectedEmpty: !yleDlAvailable,
+			requiresYleDl: true,
+		},
+		{
+			name:          "root yle.fi URL",
+			url:           "https://yle.fi/areena",
+			expectedCmd:   "yle-dl",
+			expectedEmpty: !yleDlAvailable,
+			requiresYleDl: true,
+		},
+		{
+			name:          "non-yle.fi URL",
+			url:           "https://youtube.com/watch?v=123",
+			expectedEmpty: true,
+		},
+		{
+			name:          "invalid URL",
+			url:           "not-a-url",
+			expectedEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := getSpecialExtractor(tt.url)
+
+			if tt.expectedEmpty {
+				if extractor.Command != "" {
+					t.Errorf("getSpecialExtractor(%q) should return empty extractor, got Command=%q", tt.url, extractor.Command)
+				}
+			} else {
+				if extractor.Command != tt.expectedCmd {
+					t.Errorf("getSpecialExtractor(%q) Command = %q, expected %q", tt.url, extractor.Command, tt.expectedCmd)
+				}
+				if extractor.URLMatcher == nil {
+					t.Error("URLMatcher should not be nil")
+				}
+				if extractor.DownloadFunc == nil {
+					t.Error("DownloadFunc should not be nil")
+				}
+				if tt.requiresYleDl && extractor.Command == "yle-dl" {
+					if extractor.SupportsProxy {
+						t.Error("yle-dl extractor should not support proxy")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestIsCommandAvailable(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		expected bool
+	}{
+		{
+			name:     "existing command",
+			cmd:      "go",
+			expected: true,
+		},
+		{
+			name:     "non-existent command",
+			cmd:      "definitely-does-not-exist-command-xyz123",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isCommandAvailable(tt.cmd)
+			if result != tt.expected {
+				t.Errorf("isCommandAvailable(%q) = %v, expected %v", tt.cmd, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduced `SpecialExtractor` type to handle specific download commands while falling back to yt-dlp if such extractors are not available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a pluggable special extractor flow for site-specific downloads with graceful fallback.
> 
> - New `SpecialExtractor` and `ExtractorFunc` abstractions; `getSpecialExtractor` selects `yle-dl` for `yle.fi` when available
> - `DownloadVideo` now tries the selected extractor first, then falls back to `yt-dlp`
> - Added `tryDownloadWithExtractor` with proxy cycling support; `yle-dl` marked as not supporting proxy
> - Split `attemptDownload` into `attemptYtDlpDownload` (now handles `--proxy`) and `attemptYleDlDownload`
> - New helpers: `isYleFiURL`, `isCommandAvailable`
> - Tests added for `isYleFiURL`, `getSpecialExtractor`, and `isCommandAvailable`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e52fb7bff9df1ed4079bf09154a60484de9dd37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->