### PR TITLE
Add /stats command with video poster and reaction tracking

### DIFF
--- a/internal/chain/chain.go
+++ b/internal/chain/chain.go
@@ -29,11 +29,13 @@ func NewChainOfResponsibility() *HandlerChain {
 	constructTextResponseHandler := &handlers.ConstructTextResponseHandler{}
 
 	videoResponseHandler := &handlers.VideoResponseHandler{}
+	videoStatsHandler := &handlers.VideoStatsHandler{}
 	imageResponseHandler := &handlers.ImageResponseHandler{}
 	deleteMessageHandler := &handlers.DeleteMessageHandler{}
 	textResponseHandler := &handlers.TextResponseHandler{}
 	tuplillaResponseHandler := &handlers.TuplillaResponseHandler{}
 	hyvaSuomiResponseHandler := &handlers.HyvaSuomiResponseHandler{}
+	statsHandler := &handlers.StatsHandler{}
 
 	endOfChainHandler := &handlers.EndOfChainHandler{}
 
@@ -49,11 +51,13 @@ func NewChainOfResponsibility() *HandlerChain {
 	videoPostprocessingHandler.SetNext(repostDetectionHandler)
 	repostDetectionHandler.SetNext(euriborHandler)
 
-	euriborHandler.SetNext(tuplillaResponseHandler)
+	euriborHandler.SetNext(statsHandler)
+	statsHandler.SetNext(tuplillaResponseHandler)
 
 	tuplillaResponseHandler.SetNext(hyvaSuomiResponseHandler)
 	hyvaSuomiResponseHandler.SetNext(videoResponseHandler)
-	videoResponseHandler.SetNext(markForNaggingHandler)
+	videoResponseHandler.SetNext(videoStatsHandler)
+	videoStatsHandler.SetNext(markForNaggingHandler)
 	markForNaggingHandler.SetNext(markForDeletionHandler)
 	markForDeletionHandler.SetNext(constructTextResponseHandler)
 	constructTextResponseHandler.SetNext(imageResponseHandler)

--- a/internal/handlers/construct_text_response_handler.go
+++ b/internal/handlers/construct_text_response_handler.go
@@ -45,6 +45,8 @@ func (r *ConstructTextResponseHandler) Execute(m *Context) {
 			m.replyToId = m.id
 			m.shouldReplyToMessage = true
 		}
+	case Stats:
+		responseText = m.textResponse
 	case Euribor:
 		responseText = fmt.Sprintf(
 			`

--- a/internal/handlers/context.go
+++ b/internal/handlers/context.go
@@ -30,6 +30,7 @@ const (
 	Ping          Action = "ping"
 	Euribor       Action = "euribor"
 	Version       Action = "version"
+	Stats         Action = "stats"
 )
 
 var ActionMap = map[Action]ActionDescription{
@@ -38,6 +39,7 @@ var ActionMap = map[Action]ActionDescription{
 	Euribor:       "Tuoreet Euribor-korot",
 	Ping:          "Ping",
 	Version:       "Version",
+	Stats:         "Videopostaajien tilastot",
 }
 
 type Context struct {
@@ -99,4 +101,9 @@ type Context struct {
 	pendingFingerprintDbPath  string
 	pendingFingerprintGroupId string
 	pendingFingerprint        []byte
+
+	// Video stats tracking
+	posterUserId   string
+	posterUsername string
+	botMessageId   string
 }

--- a/internal/handlers/end_of_chain_handler.go
+++ b/internal/handlers/end_of_chain_handler.go
@@ -24,10 +24,12 @@ func (h *EndOfChainHandler) Execute(m *Context) {
 	if m.action == DownloadVideo {
 		utils.CleanupTmpDir(config.FromEnv().YTDLP_TMP_DIR)
 
-		// Cleanup old fingerprints
+		// Cleanup old fingerprints (init DB first in case no video was downloaded this run)
 		cfg := config.FromEnv()
 		dbPath := filepath.Join(cfg.REPOST_DB_DIR, "repost_fingerprints.duckdb")
-		if err := utils.CleanupOldFingerprints(dbPath, cleanupMaxAge); err != nil {
+		if err := utils.InitRepostDB(dbPath); err != nil {
+			slog.Warn("Failed to initialize repost database for cleanup", "error", err)
+		} else if err := utils.CleanupOldFingerprints(dbPath, cleanupMaxAge); err != nil {
 			slog.Warn("Failed to cleanup old fingerprints", "error", err)
 		}
 	}

--- a/internal/handlers/generic_message_handler.go
+++ b/internal/handlers/generic_message_handler.go
@@ -50,6 +50,8 @@ func (mp *GenericMessageHandler) Execute(m *Context) {
 			m.action = Euribor
 		case Version:
 			m.action = Version
+		case Stats:
+			m.action = Stats
 		}
 
 		m.parsedText = strings.TrimSpace(strings.Replace(textWithoutPrefixOrSuffix, extractedAction, "", 1))

--- a/internal/handlers/on_text_handler.go
+++ b/internal/handlers/on_text_handler.go
@@ -27,6 +27,14 @@ func (mp *OnTextHandler) Execute(m *Context) {
 				m.replyToId = fmt.Sprint(c.Message().ReplyTo.ID)
 				m.shouldReplyToMessage = true
 			}
+
+			if message.Sender != nil {
+				m.posterUserId = strconv.FormatInt(message.Sender.ID, 10)
+				m.posterUsername = message.Sender.Username
+				if m.posterUsername == "" {
+					m.posterUsername = strings.TrimSpace(message.Sender.FirstName + " " + message.Sender.LastName)
+				}
+			}
 		}
 	case Discord:
 		message := m.DiscordMessage
@@ -38,6 +46,11 @@ func (mp *OnTextHandler) Execute(m *Context) {
 				m.shouldReplyToMessage = true
 			}
 			m.chatId = message.ChannelID
+
+			if message.Author != nil {
+				m.posterUserId = message.Author.ID
+				m.posterUsername = message.Author.Username
+			}
 		}
 	}
 	mp.next.Execute(m)

--- a/internal/handlers/stats_handler.go
+++ b/internal/handlers/stats_handler.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+
+	"github.com/napuu/gpsp-bot/internal/config"
+	"github.com/napuu/gpsp-bot/pkg/utils"
+)
+
+type StatsHandler struct {
+	next ContextHandler
+}
+
+func (h *StatsHandler) Execute(m *Context) {
+	slog.Debug("Entering StatsHandler")
+
+	if m.action == Stats {
+		cfg := config.FromEnv()
+		dbPath := filepath.Join(cfg.REPOST_DB_DIR, statsDBFileName)
+
+		var platform string
+		switch m.Service {
+		case Telegram:
+			platform = "telegram"
+		case Discord:
+			platform = "discord"
+		}
+		groupId := platform + ":" + m.chatId
+
+		posters, postersErr := utils.GetGroupLeaderboard(dbPath, groupId, 10)
+		thumbsUp, thumbsUpErr := utils.GetTopThumbsUp(dbPath, groupId, 5)
+		thumbsDown, thumbsDownErr := utils.GetTopThumbsDown(dbPath, groupId, 5)
+		reposters, repostersErr := utils.GetTopReposters(dbPath, groupId, 5)
+
+		m.textResponse = buildStatsText(posters, postersErr, thumbsUp, thumbsUpErr, thumbsDown, thumbsDownErr, reposters, repostersErr)
+	}
+
+	h.next.Execute(m)
+}
+
+func (h *StatsHandler) SetNext(next ContextHandler) {
+	h.next = next
+}
+
+func buildStatsText(
+	posters []utils.PosterStat, postersErr error,
+	thumbsUp []utils.ReactionStat, thumbsUpErr error,
+	thumbsDown []utils.ReactionStat, thumbsDownErr error,
+	reposters []utils.RepostStat, repostersErr error,
+) string {
+	var sb strings.Builder
+
+	sb.WriteString("Top video posters:\n")
+	appendPosterSection(&sb, posters, postersErr)
+
+	sb.WriteString("\n👍 Most liked:\n")
+	appendReactionSection(&sb, thumbsUp, thumbsUpErr)
+
+	sb.WriteString("\n👎 Most disliked:\n")
+	appendReactionSection(&sb, thumbsDown, thumbsDownErr)
+
+	sb.WriteString("\nTop reposters:\n")
+	appendReposterSection(&sb, reposters, repostersErr)
+
+	return sb.String()
+}
+
+func appendPosterSection(sb *strings.Builder, posters []utils.PosterStat, err error) {
+	if err != nil {
+		sb.WriteString("(error fetching data)\n")
+		return
+	}
+	if len(posters) == 0 {
+		sb.WriteString("No videos posted yet.\n")
+		return
+	}
+	for i, p := range posters {
+		name := p.Username
+		if name == "" {
+			name = p.UserId
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s — %d video", i+1, name, p.PostCount))
+		if p.PostCount != 1 {
+			sb.WriteString("s")
+		}
+		sb.WriteString("\n")
+	}
+}
+
+func appendReactionSection(sb *strings.Builder, videos []utils.ReactionStat, err error) {
+	if err != nil {
+		sb.WriteString("(error fetching data)\n")
+		return
+	}
+	if len(videos) == 0 {
+		sb.WriteString("None yet.\n")
+		return
+	}
+	for i, v := range videos {
+		name := v.Username
+		if name == "" {
+			name = "unknown"
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s — %d (%s)\n", i+1, name, v.ReactionCount, v.SourceUrl))
+	}
+}
+
+func appendReposterSection(sb *strings.Builder, reposters []utils.RepostStat, err error) {
+	if err != nil {
+		sb.WriteString("(error fetching data)\n")
+		return
+	}
+	if len(reposters) == 0 {
+		sb.WriteString("No reposts detected.\n")
+		return
+	}
+	for i, r := range reposters {
+		name := r.Username
+		if name == "" {
+			name = r.UserId
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s — %d repost", i+1, name, r.RepostCount))
+		if r.RepostCount != 1 {
+			sb.WriteString("s")
+		}
+		sb.WriteString("\n")
+	}
+}

--- a/internal/handlers/stats_handler.go
+++ b/internal/handlers/stats_handler.go
@@ -27,13 +27,26 @@ func (h *StatsHandler) Execute(m *Context) {
 			platform = "telegram"
 		case Discord:
 			platform = "discord"
+		default:
+			slog.Warn("StatsHandler: unknown service", "service", m.Service)
+			h.next.Execute(m)
+			return
 		}
 		groupId := platform + ":" + m.chatId
 
-		posters, postersErr := utils.GetGroupLeaderboard(dbPath, groupId, 10)
-		thumbsUp, thumbsUpErr := utils.GetTopThumbsUp(dbPath, groupId, 5)
-		thumbsDown, thumbsDownErr := utils.GetTopThumbsDown(dbPath, groupId, 5)
-		reposters, repostersErr := utils.GetTopReposters(dbPath, groupId, 5)
+		db, err := utils.OpenStatsDB(dbPath)
+		if err != nil {
+			slog.Warn("Failed to open stats DB", "error", err)
+			m.textResponse = buildStatsText(nil, err, nil, err, nil, err, nil, err)
+			h.next.Execute(m)
+			return
+		}
+		defer db.Close()
+
+		posters, postersErr := utils.GetGroupLeaderboard(db, groupId, 10)
+		thumbsUp, thumbsUpErr := utils.GetTopThumbsUp(db, groupId, 5)
+		thumbsDown, thumbsDownErr := utils.GetTopThumbsDown(db, groupId, 5)
+		reposters, repostersErr := utils.GetTopReposters(db, groupId, 5)
 
 		m.textResponse = buildStatsText(posters, postersErr, thumbsUp, thumbsUpErr, thumbsDown, thumbsDownErr, reposters, repostersErr)
 	}

--- a/internal/handlers/stats_handler_test.go
+++ b/internal/handlers/stats_handler_test.go
@@ -21,12 +21,17 @@ func setupStatsTestDB(t *testing.T) string {
 func TestStatsHandlerSetsTextResponse(t *testing.T) {
 	dbPath := setupStatsTestDB(t)
 
-	if err := utils.RecordVideoPost(dbPath, utils.VideoStatEntry{
+	db, err := utils.OpenStatsDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStatsDB failed: %v", err)
+	}
+	if err := utils.RecordVideoPost(db, utils.VideoStatEntry{
 		Platform: "discord", GroupId: "discord:999", UserId: "u1", Username: "alice",
 		SourceUrl: "https://youtube.com/watch?v=1", BotMessageId: "m1", PostedAt: time.Now(),
 	}); err != nil {
 		t.Fatalf("RecordVideoPost failed: %v", err)
 	}
+	db.Close()
 
 	t.Setenv("ENABLED_FEATURES", "stats")
 	t.Setenv("REPOST_DB_DIR", filepath.Dir(dbPath))

--- a/internal/handlers/stats_handler_test.go
+++ b/internal/handlers/stats_handler_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/napuu/gpsp-bot/pkg/utils"
+)
+
+func setupStatsTestDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "repost_fingerprints.duckdb")
+	if err := utils.InitRepostDB(dbPath); err != nil {
+		t.Fatalf("InitRepostDB failed: %v", err)
+	}
+	return dbPath
+}
+
+func TestStatsHandlerSetsTextResponse(t *testing.T) {
+	dbPath := setupStatsTestDB(t)
+
+	if err := utils.RecordVideoPost(dbPath, utils.VideoStatEntry{
+		Platform: "discord", GroupId: "discord:999", UserId: "u1", Username: "alice",
+		SourceUrl: "https://youtube.com/watch?v=1", BotMessageId: "m1", PostedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("RecordVideoPost failed: %v", err)
+	}
+
+	t.Setenv("ENABLED_FEATURES", "stats")
+	t.Setenv("REPOST_DB_DIR", filepath.Dir(dbPath))
+
+	ctx := &Context{
+		Service: Discord,
+		chatId:  "999",
+		action:  Stats,
+	}
+
+	statsHandler := &StatsHandler{}
+	end := &mockHandler{}
+	statsHandler.SetNext(end)
+
+	statsHandler.Execute(ctx)
+
+	if ctx.textResponse == "" {
+		t.Error("expected textResponse to be set, got empty string")
+	}
+	if !strings.Contains(ctx.textResponse, "alice") {
+		t.Errorf("expected textResponse to contain 'alice', got: %q", ctx.textResponse)
+	}
+	if !end.executed {
+		t.Error("expected next handler to be called")
+	}
+}
+
+func TestStatsHandlerSkipsWhenActionIsNotStats(t *testing.T) {
+	ctx := &Context{
+		Service: Discord,
+		chatId:  "999",
+		action:  Ping,
+	}
+
+	statsHandler := &StatsHandler{}
+	end := &mockHandler{}
+	statsHandler.SetNext(end)
+
+	statsHandler.Execute(ctx)
+
+	if ctx.textResponse != "" {
+		t.Errorf("expected empty textResponse for non-stats action, got: %q", ctx.textResponse)
+	}
+	if !end.executed {
+		t.Error("expected next handler to be called")
+	}
+}
+
+func TestBuildStatsTextWithData(t *testing.T) {
+	posters := []utils.PosterStat{
+		{UserId: "u1", Username: "alice", PostCount: 5},
+		{UserId: "u2", Username: "bob", PostCount: 2},
+	}
+	thumbsUp := []utils.ReactionStat{
+		{BotMessageId: "m1", Username: "alice", SourceUrl: "https://example.com/v1", ReactionCount: 7, PostedAt: time.Now()},
+	}
+	thumbsDown := []utils.ReactionStat{
+		{BotMessageId: "m2", Username: "bob", SourceUrl: "https://example.com/v2", ReactionCount: 3, PostedAt: time.Now()},
+	}
+	reposters := []utils.RepostStat{
+		{UserId: "u2", Username: "bob", RepostCount: 4},
+	}
+
+	result := buildStatsText(posters, nil, thumbsUp, nil, thumbsDown, nil, reposters, nil)
+
+	if !strings.Contains(result, "alice") {
+		t.Errorf("expected result to contain 'alice', got: %q", result)
+	}
+	if !strings.Contains(result, "5 videos") {
+		t.Errorf("expected result to contain '5 videos', got: %q", result)
+	}
+	if !strings.Contains(result, "👍") {
+		t.Errorf("expected result to contain thumbs up section, got: %q", result)
+	}
+	if !strings.Contains(result, "👎") {
+		t.Errorf("expected result to contain thumbs down section, got: %q", result)
+	}
+	if !strings.Contains(result, "4 reposts") {
+		t.Errorf("expected result to contain '4 reposts', got: %q", result)
+	}
+}
+
+func TestBuildStatsTextEmpty(t *testing.T) {
+	result := buildStatsText(nil, nil, nil, nil, nil, nil, nil, nil)
+
+	if !strings.Contains(result, "No videos posted yet") {
+		t.Errorf("expected empty-state message for posters, got: %q", result)
+	}
+	if !strings.Contains(result, "None yet") {
+		t.Errorf("expected empty-state message for reactions, got: %q", result)
+	}
+	if !strings.Contains(result, "No reposts detected") {
+		t.Errorf("expected empty-state message for reposters, got: %q", result)
+	}
+}
+
+func TestBuildStatsTextSingularPlural(t *testing.T) {
+	posters := []utils.PosterStat{{UserId: "u1", Username: "alice", PostCount: 1}}
+	reposters := []utils.RepostStat{{UserId: "u2", Username: "bob", RepostCount: 1}}
+
+	result := buildStatsText(posters, nil, nil, nil, nil, nil, reposters, nil)
+
+	if strings.Contains(result, "1 videos") {
+		t.Errorf("expected singular '1 video', got: %q", result)
+	}
+	if !strings.Contains(result, "1 video") {
+		t.Errorf("expected '1 video' in result, got: %q", result)
+	}
+	if strings.Contains(result, "1 reposts") {
+		t.Errorf("expected singular '1 repost', got: %q", result)
+	}
+	if !strings.Contains(result, "1 repost") {
+		t.Errorf("expected '1 repost' in result, got: %q", result)
+	}
+}

--- a/internal/handlers/video_response_handler.go
+++ b/internal/handlers/video_response_handler.go
@@ -38,6 +38,7 @@ func (r *VideoResponseHandler) Execute(m *Context) {
 				slog.Warn("Failed to send video", "error", err)
 			} else {
 				m.sendVideoSucceeded = true
+				m.botMessageId = fmt.Sprint(sentMessage.ID)
 				// Store fingerprint with the message ID of the bot's response
 				// Skip storage if this is a repost to avoid duplicate entries
 				if !m.isRepost && len(m.pendingFingerprint) > 0 {
@@ -85,6 +86,7 @@ func (r *VideoResponseHandler) Execute(m *Context) {
 				slog.Warn("Failed to send video", "error", err)
 			} else {
 				m.sendVideoSucceeded = true
+				m.botMessageId = sentMessage.ID
 				// Store fingerprint with the message ID of the bot's response
 				// Skip storage if this is a repost to avoid duplicate entries
 				if !m.isRepost && len(m.pendingFingerprint) > 0 {

--- a/internal/handlers/video_stats_handler.go
+++ b/internal/handlers/video_stats_handler.go
@@ -1,0 +1,55 @@
+package handlers
+
+import (
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/napuu/gpsp-bot/internal/config"
+	"github.com/napuu/gpsp-bot/pkg/utils"
+)
+
+const statsDBFileName = "repost_fingerprints.duckdb"
+
+type VideoStatsHandler struct {
+	next ContextHandler
+}
+
+func (h *VideoStatsHandler) Execute(m *Context) {
+	slog.Debug("Entering VideoStatsHandler")
+
+	if m.sendVideoSucceeded && m.action == DownloadVideo && m.botMessageId != "" {
+		cfg := config.FromEnv()
+		dbPath := filepath.Join(cfg.REPOST_DB_DIR, statsDBFileName)
+
+		var platform string
+		switch m.Service {
+		case Telegram:
+			platform = "telegram"
+		case Discord:
+			platform = "discord"
+		}
+
+		entry := utils.VideoStatEntry{
+			Platform:     platform,
+			GroupId:      platform + ":" + m.chatId,
+			UserId:       m.posterUserId,
+			Username:     m.posterUsername,
+			SourceUrl:    m.url,
+			BotMessageId: m.botMessageId,
+			IsRepost:     m.isRepost,
+			PostedAt:     time.Now(),
+		}
+		if err := utils.RecordVideoPost(dbPath, entry); err != nil {
+			slog.Warn("Failed to record video stat", "error", err)
+		} else {
+			slog.Debug("Video stat recorded", "platform", platform, "user", m.posterUsername, "url", m.url)
+		}
+	}
+
+	h.next.Execute(m)
+}
+
+func (h *VideoStatsHandler) SetNext(next ContextHandler) {
+	h.next = next
+}

--- a/internal/handlers/video_stats_handler.go
+++ b/internal/handlers/video_stats_handler.go
@@ -28,7 +28,19 @@ func (h *VideoStatsHandler) Execute(m *Context) {
 			platform = "telegram"
 		case Discord:
 			platform = "discord"
+		default:
+			slog.Warn("VideoStatsHandler: unknown service, skipping", "service", m.Service)
+			h.next.Execute(m)
+			return
 		}
+
+		db, err := utils.OpenStatsDB(dbPath)
+		if err != nil {
+			slog.Warn("Failed to open stats DB", "error", err)
+			h.next.Execute(m)
+			return
+		}
+		defer db.Close()
 
 		entry := utils.VideoStatEntry{
 			Platform:     platform,
@@ -40,7 +52,7 @@ func (h *VideoStatsHandler) Execute(m *Context) {
 			IsRepost:     m.isRepost,
 			PostedAt:     time.Now(),
 		}
-		if err := utils.RecordVideoPost(dbPath, entry); err != nil {
+		if err := utils.RecordVideoPost(db, entry); err != nil {
 			slog.Warn("Failed to record video stat", "error", err)
 		} else {
 			slog.Debug("Video stat recorded", "platform", platform, "user", m.posterUsername, "url", m.url)

--- a/internal/platforms/discord_api.go
+++ b/internal/platforms/discord_api.go
@@ -2,11 +2,13 @@ package platforms
 
 import (
 	"log/slog"
+	"path/filepath"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/napuu/gpsp-bot/internal/chain"
 	"github.com/napuu/gpsp-bot/internal/config"
 	"github.com/napuu/gpsp-bot/internal/handlers"
+	"github.com/napuu/gpsp-bot/pkg/utils"
 )
 
 func wrapDiscoHandler(chain *chain.HandlerChain) func(s *discordgo.Session, m *discordgo.MessageCreate) {
@@ -26,7 +28,8 @@ func wrapDiscoHandler(chain *chain.HandlerChain) func(s *discordgo.Session, m *d
 }
 
 func RunDiscordBot() {
-	token := config.FromEnv().DISCORD_TOKEN
+	cfg := config.FromEnv()
+	token := cfg.DISCORD_TOKEN
 	dg, err := discordgo.New("Bot " + token)
 	if err != nil {
 		slog.Error("Error creating Discord session", "error", err)
@@ -36,11 +39,33 @@ func RunDiscordBot() {
 	// Create the chain of responsibility
 	chain := chain.NewChainOfResponsibility()
 
+	dbPath := filepath.Join(cfg.REPOST_DB_DIR, "repost_fingerprints.duckdb")
+
 	// Add a handler for messages
 	dg.AddHandler(wrapDiscoHandler(chain))
 
+	// Add reaction tracking handlers
+	dg.AddHandler(func(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
+		if r.UserID == s.State.User.ID {
+			return
+		}
+		groupId := "discord:" + r.ChannelID
+		if err := utils.UpdateReactionCount(dbPath, "discord", groupId, r.MessageID, r.Emoji.Name, +1); err != nil {
+			slog.Warn("Failed to update Discord reaction count", "error", err)
+		}
+	})
+	dg.AddHandler(func(s *discordgo.Session, r *discordgo.MessageReactionRemove) {
+		if r.UserID == s.State.User.ID {
+			return
+		}
+		groupId := "discord:" + r.ChannelID
+		if err := utils.UpdateReactionCount(dbPath, "discord", groupId, r.MessageID, r.Emoji.Name, -1); err != nil {
+			slog.Warn("Failed to update Discord reaction count", "error", err)
+		}
+	})
+
 	// Specify intents
-	dg.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsDirectMessages
+	dg.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsDirectMessages | discordgo.IntentsGuildMessageReactions
 
 	// Open the connection
 	err = dg.Open()

--- a/internal/platforms/discord_api.go
+++ b/internal/platforms/discord_api.go
@@ -40,6 +40,11 @@ func RunDiscordBot() {
 	chain := chain.NewChainOfResponsibility()
 
 	dbPath := filepath.Join(cfg.REPOST_DB_DIR, "repost_fingerprints.duckdb")
+	statsDB, err := utils.OpenStatsDB(dbPath)
+	if err != nil {
+		slog.Error("Failed to open stats DB for reaction tracking", "error", err)
+		return
+	}
 
 	// Add a handler for messages
 	dg.AddHandler(wrapDiscoHandler(chain))
@@ -50,7 +55,7 @@ func RunDiscordBot() {
 			return
 		}
 		groupId := "discord:" + r.ChannelID
-		if err := utils.UpdateReactionCount(dbPath, "discord", groupId, r.MessageID, r.Emoji.Name, +1); err != nil {
+		if err := utils.UpdateReactionCount(statsDB, "discord", groupId, r.MessageID, r.Emoji.Name, +1); err != nil {
 			slog.Warn("Failed to update Discord reaction count", "error", err)
 		}
 	})
@@ -59,7 +64,7 @@ func RunDiscordBot() {
 			return
 		}
 		groupId := "discord:" + r.ChannelID
-		if err := utils.UpdateReactionCount(dbPath, "discord", groupId, r.MessageID, r.Emoji.Name, -1); err != nil {
+		if err := utils.UpdateReactionCount(statsDB, "discord", groupId, r.MessageID, r.Emoji.Name, -1); err != nil {
 			slog.Warn("Failed to update Discord reaction count", "error", err)
 		}
 	})

--- a/internal/platforms/telegram_api.go
+++ b/internal/platforms/telegram_api.go
@@ -1,12 +1,15 @@
 package platforms
 
 import (
+	"fmt"
 	"log/slog"
+	"path/filepath"
 	"time"
 
 	"github.com/napuu/gpsp-bot/internal/chain"
 	"github.com/napuu/gpsp-bot/internal/config"
 	"github.com/napuu/gpsp-bot/internal/handlers"
+	"github.com/napuu/gpsp-bot/pkg/utils"
 
 	tele "gopkg.in/telebot.v4"
 )
@@ -33,7 +36,9 @@ func TelebotCompatibleVisibleCommands() []tele.Command {
 }
 
 func RunTelegramBot() {
-	bot := getTelegramBot()
+	cfg := config.FromEnv()
+	dbPath := filepath.Join(cfg.REPOST_DB_DIR, "repost_fingerprints.duckdb")
+	bot := getTelegramBot(dbPath)
 	chain := chain.NewChainOfResponsibility()
 
 	err := bot.SetCommands(TelebotCompatibleVisibleCommands())
@@ -46,18 +51,45 @@ func RunTelegramBot() {
 	go bot.Start()
 }
 
-func getTelegramBot() *tele.Bot {
+func getTelegramBot(dbPath string) *tele.Bot {
+	inner := &tele.LongPoller{
+		Timeout: 10 * time.Second,
+		AllowedUpdates: []string{
+			"message",
+			"message_reaction",
+		},
+	}
+
+	poller := tele.NewMiddlewarePoller(inner, func(u *tele.Update) bool {
+		if u.MessageReaction != nil {
+			mr := u.MessageReaction
+			groupId := "telegram:" + fmt.Sprint(mr.Chat.ID)
+			botMsgId := fmt.Sprint(mr.MessageID)
+
+			// Find added reactions (present in New but not Old)
+			for _, r := range mr.NewReaction {
+				if !containsEmoji(mr.OldReaction, r.Emoji) {
+					if err := utils.UpdateReactionCount(dbPath, "telegram", groupId, botMsgId, r.Emoji, +1); err != nil {
+						slog.Warn("Failed to update Telegram reaction count", "error", err)
+					}
+				}
+			}
+			// Find removed reactions (present in Old but not New)
+			for _, r := range mr.OldReaction {
+				if !containsEmoji(mr.NewReaction, r.Emoji) {
+					if err := utils.UpdateReactionCount(dbPath, "telegram", groupId, botMsgId, r.Emoji, -1); err != nil {
+						slog.Warn("Failed to update Telegram reaction count", "error", err)
+					}
+				}
+			}
+		}
+		return true
+	})
+
 	pref := tele.Settings{
 		Token:     config.FromEnv().TELEGRAM_TOKEN,
 		ParseMode: tele.ModeHTML,
-		Poller: &tele.LongPoller{
-			Timeout: 10 * time.Second,
-			AllowedUpdates: []string{
-				"message",
-				// TODO - take this into use
-				// "message_reaction",
-			},
-		},
+		Poller:    poller,
 	}
 
 	b, err := tele.NewBot(pref)
@@ -66,4 +98,14 @@ func getTelegramBot() *tele.Bot {
 	}
 
 	return b
+}
+
+// containsEmoji reports whether emoji e is present in the reaction slice.
+func containsEmoji(reactions []tele.Reaction, emoji string) bool {
+	for _, r := range reactions {
+		if r.Emoji == emoji {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/platforms/telegram_api.go
+++ b/internal/platforms/telegram_api.go
@@ -1,6 +1,7 @@
 package platforms
 
 import (
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -38,10 +39,15 @@ func TelebotCompatibleVisibleCommands() []tele.Command {
 func RunTelegramBot() {
 	cfg := config.FromEnv()
 	dbPath := filepath.Join(cfg.REPOST_DB_DIR, "repost_fingerprints.duckdb")
-	bot := getTelegramBot(dbPath)
+	statsDB, err := utils.OpenStatsDB(dbPath)
+	if err != nil {
+		slog.Error("Failed to open stats DB for reaction tracking", "error", err)
+		return
+	}
+	bot := getTelegramBot(statsDB)
 	chain := chain.NewChainOfResponsibility()
 
-	err := bot.SetCommands(TelebotCompatibleVisibleCommands())
+	err = bot.SetCommands(TelebotCompatibleVisibleCommands())
 	if err != nil {
 		slog.Error(err.Error())
 	}
@@ -51,7 +57,7 @@ func RunTelegramBot() {
 	go bot.Start()
 }
 
-func getTelegramBot(dbPath string) *tele.Bot {
+func getTelegramBot(statsDB *sql.DB) *tele.Bot {
 	inner := &tele.LongPoller{
 		Timeout: 10 * time.Second,
 		AllowedUpdates: []string{
@@ -69,7 +75,7 @@ func getTelegramBot(dbPath string) *tele.Bot {
 			// Find added reactions (present in New but not Old)
 			for _, r := range mr.NewReaction {
 				if !containsEmoji(mr.OldReaction, r.Emoji) {
-					if err := utils.UpdateReactionCount(dbPath, "telegram", groupId, botMsgId, r.Emoji, +1); err != nil {
+					if err := utils.UpdateReactionCount(statsDB, "telegram", groupId, botMsgId, r.Emoji, +1); err != nil {
 						slog.Warn("Failed to update Telegram reaction count", "error", err)
 					}
 				}
@@ -77,7 +83,7 @@ func getTelegramBot(dbPath string) *tele.Bot {
 			// Find removed reactions (present in Old but not New)
 			for _, r := range mr.OldReaction {
 				if !containsEmoji(mr.NewReaction, r.Emoji) {
-					if err := utils.UpdateReactionCount(dbPath, "telegram", groupId, botMsgId, r.Emoji, -1); err != nil {
+					if err := utils.UpdateReactionCount(statsDB, "telegram", groupId, botMsgId, r.Emoji, -1); err != nil {
 						slog.Warn("Failed to update Telegram reaction count", "error", err)
 					}
 				}

--- a/pkg/utils/repost_db.go
+++ b/pkg/utils/repost_db.go
@@ -40,7 +40,27 @@ func InitRepostDB(dbPath string) error {
 			group_id TEXT NOT NULL,
 			message_id TEXT NOT NULL,
 			created_at TIMESTAMP NOT NULL
-		)
+		);
+		CREATE SEQUENCE IF NOT EXISTS video_stats_id_seq;
+		CREATE TABLE IF NOT EXISTS video_stats (
+			id            BIGINT PRIMARY KEY DEFAULT nextval('video_stats_id_seq'),
+			platform      TEXT NOT NULL,
+			group_id      TEXT NOT NULL,
+			user_id       TEXT NOT NULL,
+			username      TEXT NOT NULL,
+			source_url    TEXT NOT NULL,
+			bot_message_id TEXT NOT NULL,
+			reaction_count  INT NOT NULL DEFAULT 0,
+			thumbs_up_count INT NOT NULL DEFAULT 0,
+			thumbs_down_count INT NOT NULL DEFAULT 0,
+			is_repost     BOOLEAN NOT NULL DEFAULT FALSE,
+			posted_at     TIMESTAMP NOT NULL
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_video_stats_lookup
+			ON video_stats (platform, group_id, bot_message_id);
+		ALTER TABLE video_stats ADD COLUMN IF NOT EXISTS thumbs_up_count INT DEFAULT 0;
+		ALTER TABLE video_stats ADD COLUMN IF NOT EXISTS thumbs_down_count INT DEFAULT 0;
+		ALTER TABLE video_stats ADD COLUMN IF NOT EXISTS is_repost BOOLEAN DEFAULT FALSE;
 	`
 
 	_, err = conn.Exec(schema)

--- a/pkg/utils/repost_db.go
+++ b/pkg/utils/repost_db.go
@@ -50,7 +50,6 @@ func InitRepostDB(dbPath string) error {
 			username      TEXT NOT NULL,
 			source_url    TEXT NOT NULL,
 			bot_message_id TEXT NOT NULL,
-			reaction_count  INT NOT NULL DEFAULT 0,
 			thumbs_up_count INT NOT NULL DEFAULT 0,
 			thumbs_down_count INT NOT NULL DEFAULT 0,
 			is_repost     BOOLEAN NOT NULL DEFAULT FALSE,
@@ -58,6 +57,9 @@ func InitRepostDB(dbPath string) error {
 		);
 		CREATE UNIQUE INDEX IF NOT EXISTS idx_video_stats_lookup
 			ON video_stats (platform, group_id, bot_message_id);
+		-- Migrate pre-existing video_stats tables that were created before
+		-- these columns were added. DuckDB's ALTER TABLE does not support
+		-- NOT NULL with ADD COLUMN, so the defaults are looser than above.
 		ALTER TABLE video_stats ADD COLUMN IF NOT EXISTS thumbs_up_count INT DEFAULT 0;
 		ALTER TABLE video_stats ADD COLUMN IF NOT EXISTS thumbs_down_count INT DEFAULT 0;
 		ALTER TABLE video_stats ADD COLUMN IF NOT EXISTS is_repost BOOLEAN DEFAULT FALSE;

--- a/pkg/utils/stats_db.go
+++ b/pkg/utils/stats_db.go
@@ -46,49 +46,43 @@ type RepostStat struct {
 	RepostCount int
 }
 
-// RecordVideoPost inserts one row into video_stats for a successful video send.
-func RecordVideoPost(dbPath string, entry VideoStatEntry) error {
+// OpenStatsDB opens a DuckDB connection for stats queries. Callers are
+// responsible for closing the returned *sql.DB.
+func OpenStatsDB(dbPath string) (*sql.DB, error) {
 	conn, err := sql.Open("duckdb", dbPath)
 	if err != nil {
-		return fmt.Errorf("failed to open DuckDB: %w", err)
+		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
 	}
-	defer conn.Close()
+	return conn, nil
+}
 
+// RecordVideoPost inserts one row into video_stats for a successful video send.
+func RecordVideoPost(db *sql.DB, entry VideoStatEntry) error {
 	query := `
 		INSERT INTO video_stats (platform, group_id, user_id, username, source_url, bot_message_id, is_repost, posted_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 	`
-	_, err = conn.Exec(query,
+	_, err := db.Exec(query,
 		entry.Platform, entry.GroupId, entry.UserId, entry.Username,
 		entry.SourceUrl, entry.BotMessageId, entry.IsRepost, entry.PostedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to record video stat: %w", err)
 	}
-
 	return nil
 }
 
-// UpdateReactionCount adjusts reaction counts for the given bot message and emoji.
-// emoji should be the raw emoji character (e.g. "👍"). Unrecognised emoji only
-// update the total reaction_count.
-// A delta that matches no row (not a tracked message) is silently ignored.
-func UpdateReactionCount(dbPath string, platform, groupId, botMessageId, emoji string, delta int) error {
-	conn, err := sql.Open("duckdb", dbPath)
-	if err != nil {
-		return fmt.Errorf("failed to open DuckDB: %w", err)
-	}
-	defer conn.Close()
-
+// UpdateReactionCount adjusts per-emoji reaction counts for the given bot
+// message. emoji should be the raw emoji character (e.g. "👍"). Unrecognised
+// emoji are ignored. A delta that matches no row is silently ignored.
+func UpdateReactionCount(db *sql.DB, platform, groupId, botMessageId, emoji string, delta int) error {
 	query := `
 		UPDATE video_stats
-		SET reaction_count    = reaction_count + ?,
-		    thumbs_up_count   = thumbs_up_count   + CASE WHEN ? = '👍' THEN ? ELSE 0 END,
+		SET thumbs_up_count   = thumbs_up_count   + CASE WHEN ? = '👍' THEN ? ELSE 0 END,
 		    thumbs_down_count = thumbs_down_count + CASE WHEN ? = '👎' THEN ? ELSE 0 END
 		WHERE platform = ? AND group_id = ? AND bot_message_id = ?
 	`
-	_, err = conn.Exec(query,
-		delta,
+	_, err := db.Exec(query,
 		emoji, delta,
 		emoji, delta,
 		platform, groupId, botMessageId,
@@ -96,27 +90,21 @@ func UpdateReactionCount(dbPath string, platform, groupId, botMessageId, emoji s
 	if err != nil {
 		return fmt.Errorf("failed to update reaction count: %w", err)
 	}
-
 	return nil
 }
 
 // GetGroupLeaderboard returns the top N posters by post count for the given group.
-func GetGroupLeaderboard(dbPath string, groupId string, limit int) ([]PosterStat, error) {
-	conn, err := sql.Open("duckdb", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
-	}
-	defer conn.Close()
-
+// Groups strictly by user_id so that a username change does not split a user.
+func GetGroupLeaderboard(db *sql.DB, groupId string, limit int) ([]PosterStat, error) {
 	query := `
-		SELECT user_id, username, COUNT(*) AS post_count
+		SELECT user_id, MAX(username) AS username, COUNT(*) AS post_count
 		FROM video_stats
 		WHERE group_id = ? AND is_repost = FALSE
-		GROUP BY user_id, username
+		GROUP BY user_id
 		ORDER BY post_count DESC
 		LIMIT ?
 	`
-	rows, err := conn.Query(query, groupId, limit)
+	rows, err := db.Query(query, groupId, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query leaderboard: %w", err)
 	}
@@ -134,21 +122,19 @@ func GetGroupLeaderboard(dbPath string, groupId string, limit int) ([]PosterStat
 }
 
 // GetTopThumbsUp returns the top N videos by 👍 count for the given group.
-func GetTopThumbsUp(dbPath string, groupId string, limit int) ([]ReactionStat, error) {
-	return queryTopByReactionColumn(dbPath, groupId, "thumbs_up_count", limit)
+func GetTopThumbsUp(db *sql.DB, groupId string, limit int) ([]ReactionStat, error) {
+	return queryTopByReactionColumn(db, groupId, "thumbs_up_count", limit)
 }
 
 // GetTopThumbsDown returns the top N videos by 👎 count for the given group.
-func GetTopThumbsDown(dbPath string, groupId string, limit int) ([]ReactionStat, error) {
-	return queryTopByReactionColumn(dbPath, groupId, "thumbs_down_count", limit)
+func GetTopThumbsDown(db *sql.DB, groupId string, limit int) ([]ReactionStat, error) {
+	return queryTopByReactionColumn(db, groupId, "thumbs_down_count", limit)
 }
 
-func queryTopByReactionColumn(dbPath, groupId, column string, limit int) ([]ReactionStat, error) {
-	conn, err := sql.Open("duckdb", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
+func queryTopByReactionColumn(db *sql.DB, groupId, column string, limit int) ([]ReactionStat, error) {
+	if column != "thumbs_up_count" && column != "thumbs_down_count" {
+		return nil, fmt.Errorf("invalid reaction column: %s", column)
 	}
-	defer conn.Close()
 
 	query := fmt.Sprintf(`
 		SELECT bot_message_id, username, source_url, COALESCE(%s, 0), posted_at
@@ -158,7 +144,7 @@ func queryTopByReactionColumn(dbPath, groupId, column string, limit int) ([]Reac
 		LIMIT ?
 	`, column, column, column)
 
-	rows, err := conn.Query(query, groupId, limit)
+	rows, err := db.Query(query, groupId, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query top %s: %w", column, err)
 	}
@@ -176,22 +162,16 @@ func queryTopByReactionColumn(dbPath, groupId, column string, limit int) ([]Reac
 }
 
 // GetTopReposters returns the top N users who have been caught reposting in the given group.
-func GetTopReposters(dbPath string, groupId string, limit int) ([]RepostStat, error) {
-	conn, err := sql.Open("duckdb", dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
-	}
-	defer conn.Close()
-
+func GetTopReposters(db *sql.DB, groupId string, limit int) ([]RepostStat, error) {
 	query := `
-		SELECT user_id, username, COUNT(*) AS repost_count
+		SELECT user_id, MAX(username) AS username, COUNT(*) AS repost_count
 		FROM video_stats
 		WHERE group_id = ? AND is_repost = TRUE
-		GROUP BY user_id, username
+		GROUP BY user_id
 		ORDER BY repost_count DESC
 		LIMIT ?
 	`
-	rows, err := conn.Query(query, groupId, limit)
+	rows, err := db.Query(query, groupId, limit)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query top reposters: %w", err)
 	}

--- a/pkg/utils/stats_db.go
+++ b/pkg/utils/stats_db.go
@@ -1,0 +1,209 @@
+package utils
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+const (
+	EmojiThumbsUp   = "👍"
+	EmojiThumbsDown = "👎"
+)
+
+// VideoStatEntry holds the data for one recorded video post.
+type VideoStatEntry struct {
+	Platform     string
+	GroupId      string
+	UserId       string
+	Username     string
+	SourceUrl    string
+	BotMessageId string
+	IsRepost     bool
+	PostedAt     time.Time
+}
+
+// PosterStat holds aggregated posting stats for one user.
+type PosterStat struct {
+	UserId    string
+	Username  string
+	PostCount int
+}
+
+// ReactionStat holds the most-reacted video entries.
+type ReactionStat struct {
+	BotMessageId  string
+	Username      string
+	SourceUrl     string
+	ReactionCount int
+	PostedAt      time.Time
+}
+
+// RepostStat holds repost counts per user.
+type RepostStat struct {
+	UserId      string
+	Username    string
+	RepostCount int
+}
+
+// RecordVideoPost inserts one row into video_stats for a successful video send.
+func RecordVideoPost(dbPath string, entry VideoStatEntry) error {
+	conn, err := sql.Open("duckdb", dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open DuckDB: %w", err)
+	}
+	defer conn.Close()
+
+	query := `
+		INSERT INTO video_stats (platform, group_id, user_id, username, source_url, bot_message_id, is_repost, posted_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`
+	_, err = conn.Exec(query,
+		entry.Platform, entry.GroupId, entry.UserId, entry.Username,
+		entry.SourceUrl, entry.BotMessageId, entry.IsRepost, entry.PostedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to record video stat: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateReactionCount adjusts reaction counts for the given bot message and emoji.
+// emoji should be the raw emoji character (e.g. "👍"). Unrecognised emoji only
+// update the total reaction_count.
+// A delta that matches no row (not a tracked message) is silently ignored.
+func UpdateReactionCount(dbPath string, platform, groupId, botMessageId, emoji string, delta int) error {
+	conn, err := sql.Open("duckdb", dbPath)
+	if err != nil {
+		return fmt.Errorf("failed to open DuckDB: %w", err)
+	}
+	defer conn.Close()
+
+	query := `
+		UPDATE video_stats
+		SET reaction_count    = reaction_count + ?,
+		    thumbs_up_count   = thumbs_up_count   + CASE WHEN ? = '👍' THEN ? ELSE 0 END,
+		    thumbs_down_count = thumbs_down_count + CASE WHEN ? = '👎' THEN ? ELSE 0 END
+		WHERE platform = ? AND group_id = ? AND bot_message_id = ?
+	`
+	_, err = conn.Exec(query,
+		delta,
+		emoji, delta,
+		emoji, delta,
+		platform, groupId, botMessageId,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update reaction count: %w", err)
+	}
+
+	return nil
+}
+
+// GetGroupLeaderboard returns the top N posters by post count for the given group.
+func GetGroupLeaderboard(dbPath string, groupId string, limit int) ([]PosterStat, error) {
+	conn, err := sql.Open("duckdb", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
+	}
+	defer conn.Close()
+
+	query := `
+		SELECT user_id, username, COUNT(*) AS post_count
+		FROM video_stats
+		WHERE group_id = ? AND is_repost = FALSE
+		GROUP BY user_id, username
+		ORDER BY post_count DESC
+		LIMIT ?
+	`
+	rows, err := conn.Query(query, groupId, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query leaderboard: %w", err)
+	}
+	defer rows.Close()
+
+	var result []PosterStat
+	for rows.Next() {
+		var s PosterStat
+		if err := rows.Scan(&s.UserId, &s.Username, &s.PostCount); err != nil {
+			return nil, fmt.Errorf("failed to scan leaderboard row: %w", err)
+		}
+		result = append(result, s)
+	}
+	return result, rows.Err()
+}
+
+// GetTopThumbsUp returns the top N videos by 👍 count for the given group.
+func GetTopThumbsUp(dbPath string, groupId string, limit int) ([]ReactionStat, error) {
+	return queryTopByReactionColumn(dbPath, groupId, "thumbs_up_count", limit)
+}
+
+// GetTopThumbsDown returns the top N videos by 👎 count for the given group.
+func GetTopThumbsDown(dbPath string, groupId string, limit int) ([]ReactionStat, error) {
+	return queryTopByReactionColumn(dbPath, groupId, "thumbs_down_count", limit)
+}
+
+func queryTopByReactionColumn(dbPath, groupId, column string, limit int) ([]ReactionStat, error) {
+	conn, err := sql.Open("duckdb", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
+	}
+	defer conn.Close()
+
+	query := fmt.Sprintf(`
+		SELECT bot_message_id, username, source_url, COALESCE(%s, 0), posted_at
+		FROM video_stats
+		WHERE group_id = ? AND COALESCE(%s, 0) > 0
+		ORDER BY COALESCE(%s, 0) DESC
+		LIMIT ?
+	`, column, column, column)
+
+	rows, err := conn.Query(query, groupId, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query top %s: %w", column, err)
+	}
+	defer rows.Close()
+
+	var result []ReactionStat
+	for rows.Next() {
+		var s ReactionStat
+		if err := rows.Scan(&s.BotMessageId, &s.Username, &s.SourceUrl, &s.ReactionCount, &s.PostedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan reaction stat row: %w", err)
+		}
+		result = append(result, s)
+	}
+	return result, rows.Err()
+}
+
+// GetTopReposters returns the top N users who have been caught reposting in the given group.
+func GetTopReposters(dbPath string, groupId string, limit int) ([]RepostStat, error) {
+	conn, err := sql.Open("duckdb", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open DuckDB: %w", err)
+	}
+	defer conn.Close()
+
+	query := `
+		SELECT user_id, username, COUNT(*) AS repost_count
+		FROM video_stats
+		WHERE group_id = ? AND is_repost = TRUE
+		GROUP BY user_id, username
+		ORDER BY repost_count DESC
+		LIMIT ?
+	`
+	rows, err := conn.Query(query, groupId, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query top reposters: %w", err)
+	}
+	defer rows.Close()
+
+	var result []RepostStat
+	for rows.Next() {
+		var s RepostStat
+		if err := rows.Scan(&s.UserId, &s.Username, &s.RepostCount); err != nil {
+			return nil, fmt.Errorf("failed to scan repost stat row: %w", err)
+		}
+		result = append(result, s)
+	}
+	return result, rows.Err()
+}

--- a/pkg/utils/stats_db_test.go
+++ b/pkg/utils/stats_db_test.go
@@ -1,0 +1,284 @@
+package utils
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func setupTestDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "repost_fingerprints.duckdb")
+	if err := InitRepostDB(dbPath); err != nil {
+		t.Fatalf("InitRepostDB failed: %v", err)
+	}
+	return dbPath
+}
+
+func TestRecordVideoPost(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entry := VideoStatEntry{
+		Platform:     "discord",
+		GroupId:      "discord:123",
+		UserId:       "user1",
+		Username:     "testuser",
+		SourceUrl:    "https://youtube.com/watch?v=abc",
+		BotMessageId: "msg1",
+		PostedAt:     time.Now(),
+	}
+
+	if err := RecordVideoPost(dbPath, entry); err != nil {
+		t.Fatalf("RecordVideoPost failed: %v", err)
+	}
+
+	posters, err := GetGroupLeaderboard(dbPath, "discord:123", 10)
+	if err != nil {
+		t.Fatalf("GetGroupLeaderboard failed: %v", err)
+	}
+	if len(posters) != 1 {
+		t.Fatalf("expected 1 poster, got %d", len(posters))
+	}
+	if posters[0].Username != "testuser" {
+		t.Errorf("expected username %q, got %q", "testuser", posters[0].Username)
+	}
+	if posters[0].PostCount != 1 {
+		t.Errorf("expected post count 1, got %d", posters[0].PostCount)
+	}
+}
+
+func TestGetGroupLeaderboardOrdering(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entries := []VideoStatEntry{
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u2", Username: "bob", SourceUrl: "https://example.com/2", BotMessageId: "m2", PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/3", BotMessageId: "m3", PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/4", BotMessageId: "m4", PostedAt: time.Now()},
+	}
+
+	for _, e := range entries {
+		if err := RecordVideoPost(dbPath, e); err != nil {
+			t.Fatalf("RecordVideoPost failed: %v", err)
+		}
+	}
+
+	posters, err := GetGroupLeaderboard(dbPath, "discord:123", 10)
+	if err != nil {
+		t.Fatalf("GetGroupLeaderboard failed: %v", err)
+	}
+	if len(posters) != 2 {
+		t.Fatalf("expected 2 posters, got %d", len(posters))
+	}
+	if posters[0].Username != "alice" || posters[0].PostCount != 3 {
+		t.Errorf("expected alice with 3 posts first, got %q with %d", posters[0].Username, posters[0].PostCount)
+	}
+	if posters[1].Username != "bob" || posters[1].PostCount != 1 {
+		t.Errorf("expected bob with 1 post second, got %q with %d", posters[1].Username, posters[1].PostCount)
+	}
+}
+
+func TestGetGroupLeaderboardExcludesReposts(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entries := []VideoStatEntry{
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", IsRepost: false, PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/2", BotMessageId: "m2", IsRepost: true, PostedAt: time.Now()},
+	}
+	for _, e := range entries {
+		if err := RecordVideoPost(dbPath, e); err != nil {
+			t.Fatalf("RecordVideoPost failed: %v", err)
+		}
+	}
+
+	posters, err := GetGroupLeaderboard(dbPath, "discord:123", 10)
+	if err != nil {
+		t.Fatalf("GetGroupLeaderboard failed: %v", err)
+	}
+	if len(posters) != 1 || posters[0].PostCount != 1 {
+		t.Errorf("leaderboard should only count non-reposts, got %v", posters)
+	}
+}
+
+func TestGetGroupLeaderboardIsolatesGroups(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entries := []VideoStatEntry{
+		{Platform: "discord", GroupId: "discord:111", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:222", UserId: "u2", Username: "bob", SourceUrl: "https://example.com/2", BotMessageId: "m2", PostedAt: time.Now()},
+	}
+	for _, e := range entries {
+		if err := RecordVideoPost(dbPath, e); err != nil {
+			t.Fatalf("RecordVideoPost failed: %v", err)
+		}
+	}
+
+	posters, err := GetGroupLeaderboard(dbPath, "discord:111", 10)
+	if err != nil {
+		t.Fatalf("GetGroupLeaderboard failed: %v", err)
+	}
+	if len(posters) != 1 || posters[0].Username != "alice" {
+		t.Errorf("expected only alice in group 111, got %v", posters)
+	}
+}
+
+func TestUpdateReactionCount(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entry := VideoStatEntry{
+		Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice",
+		SourceUrl: "https://example.com/1", BotMessageId: "msg1", PostedAt: time.Now(),
+	}
+	if err := RecordVideoPost(dbPath, entry); err != nil {
+		t.Fatalf("RecordVideoPost failed: %v", err)
+	}
+
+	// Add two thumbs up
+	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, +1); err != nil {
+		t.Fatalf("UpdateReactionCount +1 failed: %v", err)
+	}
+	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, +1); err != nil {
+		t.Fatalf("UpdateReactionCount +1 failed: %v", err)
+	}
+
+	videos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	if err != nil {
+		t.Fatalf("GetTopThumbsUp failed: %v", err)
+	}
+	if len(videos) != 1 {
+		t.Fatalf("expected 1 video, got %d", len(videos))
+	}
+	if videos[0].ReactionCount != 2 {
+		t.Errorf("expected thumbs_up count 2, got %d", videos[0].ReactionCount)
+	}
+
+	// Remove one thumbs up
+	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, -1); err != nil {
+		t.Fatalf("UpdateReactionCount -1 failed: %v", err)
+	}
+
+	videos, err = GetTopThumbsUp(dbPath, "discord:123", 5)
+	if err != nil {
+		t.Fatalf("GetTopThumbsUp failed: %v", err)
+	}
+	if videos[0].ReactionCount != 1 {
+		t.Errorf("expected thumbs_up count 1 after removal, got %d", videos[0].ReactionCount)
+	}
+}
+
+func TestUpdateReactionCountThumbsDown(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entry := VideoStatEntry{
+		Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice",
+		SourceUrl: "https://example.com/1", BotMessageId: "msg1", PostedAt: time.Now(),
+	}
+	if err := RecordVideoPost(dbPath, entry); err != nil {
+		t.Fatalf("RecordVideoPost failed: %v", err)
+	}
+
+	UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsDown, +1)
+	UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsDown, +1)
+	UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, +1)
+
+	downVideos, err := GetTopThumbsDown(dbPath, "discord:123", 5)
+	if err != nil {
+		t.Fatalf("GetTopThumbsDown failed: %v", err)
+	}
+	if len(downVideos) != 1 || downVideos[0].ReactionCount != 2 {
+		t.Errorf("expected 2 thumbs down, got %v", downVideos)
+	}
+
+	upVideos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	if err != nil {
+		t.Fatalf("GetTopThumbsUp failed: %v", err)
+	}
+	if len(upVideos) != 1 || upVideos[0].ReactionCount != 1 {
+		t.Errorf("expected 1 thumbs up, got %v", upVideos)
+	}
+}
+
+func TestUpdateReactionCountUnknownMessage(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "nonexistent-msg", EmojiThumbsUp, +1); err != nil {
+		t.Errorf("UpdateReactionCount on unknown message should not error, got: %v", err)
+	}
+}
+
+func TestGetTopThumbsUpOrdering(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entries := []VideoStatEntry{
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://a.com", BotMessageId: "m1", PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u2", Username: "bob", SourceUrl: "https://b.com", BotMessageId: "m2", PostedAt: time.Now()},
+	}
+	for _, e := range entries {
+		if err := RecordVideoPost(dbPath, e); err != nil {
+			t.Fatalf("RecordVideoPost failed: %v", err)
+		}
+	}
+
+	for range 3 {
+		UpdateReactionCount(dbPath, "discord", "discord:123", "m2", EmojiThumbsUp, +1)
+	}
+	UpdateReactionCount(dbPath, "discord", "discord:123", "m1", EmojiThumbsUp, +1)
+
+	videos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	if err != nil {
+		t.Fatalf("GetTopThumbsUp failed: %v", err)
+	}
+	if len(videos) != 2 {
+		t.Fatalf("expected 2 videos, got %d", len(videos))
+	}
+	if videos[0].Username != "bob" || videos[0].ReactionCount != 3 {
+		t.Errorf("expected bob with 3 thumbs up first, got %q with %d", videos[0].Username, videos[0].ReactionCount)
+	}
+}
+
+func TestGetTopThumbsUpExcludesZero(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entry := VideoStatEntry{
+		Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice",
+		SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now(),
+	}
+	if err := RecordVideoPost(dbPath, entry); err != nil {
+		t.Fatalf("RecordVideoPost failed: %v", err)
+	}
+
+	videos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	if err != nil {
+		t.Fatalf("GetTopThumbsUp failed: %v", err)
+	}
+	if len(videos) != 0 {
+		t.Errorf("expected 0 videos with no thumbs up, got %d", len(videos))
+	}
+}
+
+func TestGetTopReposters(t *testing.T) {
+	dbPath := setupTestDB(t)
+
+	entries := []VideoStatEntry{
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://a.com", BotMessageId: "m1", IsRepost: true, PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://b.com", BotMessageId: "m2", IsRepost: true, PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u2", Username: "bob", SourceUrl: "https://c.com", BotMessageId: "m3", IsRepost: true, PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u3", Username: "carol", SourceUrl: "https://d.com", BotMessageId: "m4", IsRepost: false, PostedAt: time.Now()},
+	}
+	for _, e := range entries {
+		if err := RecordVideoPost(dbPath, e); err != nil {
+			t.Fatalf("RecordVideoPost failed: %v", err)
+		}
+	}
+
+	reposters, err := GetTopReposters(dbPath, "discord:123", 10)
+	if err != nil {
+		t.Fatalf("GetTopReposters failed: %v", err)
+	}
+	if len(reposters) != 2 {
+		t.Fatalf("expected 2 reposters (carol posted original, not repost), got %d", len(reposters))
+	}
+	if reposters[0].Username != "alice" || reposters[0].RepostCount != 2 {
+		t.Errorf("expected alice with 2 reposts first, got %q with %d", reposters[0].Username, reposters[0].RepostCount)
+	}
+}

--- a/pkg/utils/stats_db_test.go
+++ b/pkg/utils/stats_db_test.go
@@ -1,22 +1,28 @@
 package utils
 
 import (
+	"database/sql"
 	"path/filepath"
 	"testing"
 	"time"
 )
 
-func setupTestDB(t *testing.T) string {
+func setupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "repost_fingerprints.duckdb")
 	if err := InitRepostDB(dbPath); err != nil {
 		t.Fatalf("InitRepostDB failed: %v", err)
 	}
-	return dbPath
+	db, err := OpenStatsDB(dbPath)
+	if err != nil {
+		t.Fatalf("OpenStatsDB failed: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
 }
 
 func TestRecordVideoPost(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entry := VideoStatEntry{
 		Platform:     "discord",
@@ -28,11 +34,11 @@ func TestRecordVideoPost(t *testing.T) {
 		PostedAt:     time.Now(),
 	}
 
-	if err := RecordVideoPost(dbPath, entry); err != nil {
+	if err := RecordVideoPost(db, entry); err != nil {
 		t.Fatalf("RecordVideoPost failed: %v", err)
 	}
 
-	posters, err := GetGroupLeaderboard(dbPath, "discord:123", 10)
+	posters, err := GetGroupLeaderboard(db, "discord:123", 10)
 	if err != nil {
 		t.Fatalf("GetGroupLeaderboard failed: %v", err)
 	}
@@ -48,7 +54,7 @@ func TestRecordVideoPost(t *testing.T) {
 }
 
 func TestGetGroupLeaderboardOrdering(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entries := []VideoStatEntry{
 		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now()},
@@ -58,12 +64,12 @@ func TestGetGroupLeaderboardOrdering(t *testing.T) {
 	}
 
 	for _, e := range entries {
-		if err := RecordVideoPost(dbPath, e); err != nil {
+		if err := RecordVideoPost(db, e); err != nil {
 			t.Fatalf("RecordVideoPost failed: %v", err)
 		}
 	}
 
-	posters, err := GetGroupLeaderboard(dbPath, "discord:123", 10)
+	posters, err := GetGroupLeaderboard(db, "discord:123", 10)
 	if err != nil {
 		t.Fatalf("GetGroupLeaderboard failed: %v", err)
 	}
@@ -78,20 +84,43 @@ func TestGetGroupLeaderboardOrdering(t *testing.T) {
 	}
 }
 
+func TestGetGroupLeaderboardGroupsByUserId(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Same user_id, different usernames (user renamed themselves).
+	entries := []VideoStatEntry{
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now()},
+		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice_renamed", SourceUrl: "https://example.com/2", BotMessageId: "m2", PostedAt: time.Now()},
+	}
+	for _, e := range entries {
+		if err := RecordVideoPost(db, e); err != nil {
+			t.Fatalf("RecordVideoPost failed: %v", err)
+		}
+	}
+
+	posters, err := GetGroupLeaderboard(db, "discord:123", 10)
+	if err != nil {
+		t.Fatalf("GetGroupLeaderboard failed: %v", err)
+	}
+	if len(posters) != 1 || posters[0].PostCount != 2 {
+		t.Errorf("expected renamed user grouped into single row with 2 posts, got %v", posters)
+	}
+}
+
 func TestGetGroupLeaderboardExcludesReposts(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entries := []VideoStatEntry{
 		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", IsRepost: false, PostedAt: time.Now()},
 		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/2", BotMessageId: "m2", IsRepost: true, PostedAt: time.Now()},
 	}
 	for _, e := range entries {
-		if err := RecordVideoPost(dbPath, e); err != nil {
+		if err := RecordVideoPost(db, e); err != nil {
 			t.Fatalf("RecordVideoPost failed: %v", err)
 		}
 	}
 
-	posters, err := GetGroupLeaderboard(dbPath, "discord:123", 10)
+	posters, err := GetGroupLeaderboard(db, "discord:123", 10)
 	if err != nil {
 		t.Fatalf("GetGroupLeaderboard failed: %v", err)
 	}
@@ -101,19 +130,19 @@ func TestGetGroupLeaderboardExcludesReposts(t *testing.T) {
 }
 
 func TestGetGroupLeaderboardIsolatesGroups(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entries := []VideoStatEntry{
 		{Platform: "discord", GroupId: "discord:111", UserId: "u1", Username: "alice", SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now()},
 		{Platform: "discord", GroupId: "discord:222", UserId: "u2", Username: "bob", SourceUrl: "https://example.com/2", BotMessageId: "m2", PostedAt: time.Now()},
 	}
 	for _, e := range entries {
-		if err := RecordVideoPost(dbPath, e); err != nil {
+		if err := RecordVideoPost(db, e); err != nil {
 			t.Fatalf("RecordVideoPost failed: %v", err)
 		}
 	}
 
-	posters, err := GetGroupLeaderboard(dbPath, "discord:111", 10)
+	posters, err := GetGroupLeaderboard(db, "discord:111", 10)
 	if err != nil {
 		t.Fatalf("GetGroupLeaderboard failed: %v", err)
 	}
@@ -123,25 +152,24 @@ func TestGetGroupLeaderboardIsolatesGroups(t *testing.T) {
 }
 
 func TestUpdateReactionCount(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entry := VideoStatEntry{
 		Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice",
 		SourceUrl: "https://example.com/1", BotMessageId: "msg1", PostedAt: time.Now(),
 	}
-	if err := RecordVideoPost(dbPath, entry); err != nil {
+	if err := RecordVideoPost(db, entry); err != nil {
 		t.Fatalf("RecordVideoPost failed: %v", err)
 	}
 
-	// Add two thumbs up
-	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, +1); err != nil {
+	if err := UpdateReactionCount(db, "discord", "discord:123", "msg1", EmojiThumbsUp, +1); err != nil {
 		t.Fatalf("UpdateReactionCount +1 failed: %v", err)
 	}
-	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, +1); err != nil {
+	if err := UpdateReactionCount(db, "discord", "discord:123", "msg1", EmojiThumbsUp, +1); err != nil {
 		t.Fatalf("UpdateReactionCount +1 failed: %v", err)
 	}
 
-	videos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	videos, err := GetTopThumbsUp(db, "discord:123", 5)
 	if err != nil {
 		t.Fatalf("GetTopThumbsUp failed: %v", err)
 	}
@@ -152,12 +180,11 @@ func TestUpdateReactionCount(t *testing.T) {
 		t.Errorf("expected thumbs_up count 2, got %d", videos[0].ReactionCount)
 	}
 
-	// Remove one thumbs up
-	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, -1); err != nil {
+	if err := UpdateReactionCount(db, "discord", "discord:123", "msg1", EmojiThumbsUp, -1); err != nil {
 		t.Fatalf("UpdateReactionCount -1 failed: %v", err)
 	}
 
-	videos, err = GetTopThumbsUp(dbPath, "discord:123", 5)
+	videos, err = GetTopThumbsUp(db, "discord:123", 5)
 	if err != nil {
 		t.Fatalf("GetTopThumbsUp failed: %v", err)
 	}
@@ -167,21 +194,21 @@ func TestUpdateReactionCount(t *testing.T) {
 }
 
 func TestUpdateReactionCountThumbsDown(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entry := VideoStatEntry{
 		Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice",
 		SourceUrl: "https://example.com/1", BotMessageId: "msg1", PostedAt: time.Now(),
 	}
-	if err := RecordVideoPost(dbPath, entry); err != nil {
+	if err := RecordVideoPost(db, entry); err != nil {
 		t.Fatalf("RecordVideoPost failed: %v", err)
 	}
 
-	UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsDown, +1)
-	UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsDown, +1)
-	UpdateReactionCount(dbPath, "discord", "discord:123", "msg1", EmojiThumbsUp, +1)
+	UpdateReactionCount(db, "discord", "discord:123", "msg1", EmojiThumbsDown, +1)
+	UpdateReactionCount(db, "discord", "discord:123", "msg1", EmojiThumbsDown, +1)
+	UpdateReactionCount(db, "discord", "discord:123", "msg1", EmojiThumbsUp, +1)
 
-	downVideos, err := GetTopThumbsDown(dbPath, "discord:123", 5)
+	downVideos, err := GetTopThumbsDown(db, "discord:123", 5)
 	if err != nil {
 		t.Fatalf("GetTopThumbsDown failed: %v", err)
 	}
@@ -189,7 +216,7 @@ func TestUpdateReactionCountThumbsDown(t *testing.T) {
 		t.Errorf("expected 2 thumbs down, got %v", downVideos)
 	}
 
-	upVideos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	upVideos, err := GetTopThumbsUp(db, "discord:123", 5)
 	if err != nil {
 		t.Fatalf("GetTopThumbsUp failed: %v", err)
 	}
@@ -199,32 +226,32 @@ func TestUpdateReactionCountThumbsDown(t *testing.T) {
 }
 
 func TestUpdateReactionCountUnknownMessage(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
-	if err := UpdateReactionCount(dbPath, "discord", "discord:123", "nonexistent-msg", EmojiThumbsUp, +1); err != nil {
+	if err := UpdateReactionCount(db, "discord", "discord:123", "nonexistent-msg", EmojiThumbsUp, +1); err != nil {
 		t.Errorf("UpdateReactionCount on unknown message should not error, got: %v", err)
 	}
 }
 
 func TestGetTopThumbsUpOrdering(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entries := []VideoStatEntry{
 		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://a.com", BotMessageId: "m1", PostedAt: time.Now()},
 		{Platform: "discord", GroupId: "discord:123", UserId: "u2", Username: "bob", SourceUrl: "https://b.com", BotMessageId: "m2", PostedAt: time.Now()},
 	}
 	for _, e := range entries {
-		if err := RecordVideoPost(dbPath, e); err != nil {
+		if err := RecordVideoPost(db, e); err != nil {
 			t.Fatalf("RecordVideoPost failed: %v", err)
 		}
 	}
 
 	for range 3 {
-		UpdateReactionCount(dbPath, "discord", "discord:123", "m2", EmojiThumbsUp, +1)
+		UpdateReactionCount(db, "discord", "discord:123", "m2", EmojiThumbsUp, +1)
 	}
-	UpdateReactionCount(dbPath, "discord", "discord:123", "m1", EmojiThumbsUp, +1)
+	UpdateReactionCount(db, "discord", "discord:123", "m1", EmojiThumbsUp, +1)
 
-	videos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	videos, err := GetTopThumbsUp(db, "discord:123", 5)
 	if err != nil {
 		t.Fatalf("GetTopThumbsUp failed: %v", err)
 	}
@@ -237,17 +264,17 @@ func TestGetTopThumbsUpOrdering(t *testing.T) {
 }
 
 func TestGetTopThumbsUpExcludesZero(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entry := VideoStatEntry{
 		Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice",
 		SourceUrl: "https://example.com/1", BotMessageId: "m1", PostedAt: time.Now(),
 	}
-	if err := RecordVideoPost(dbPath, entry); err != nil {
+	if err := RecordVideoPost(db, entry); err != nil {
 		t.Fatalf("RecordVideoPost failed: %v", err)
 	}
 
-	videos, err := GetTopThumbsUp(dbPath, "discord:123", 5)
+	videos, err := GetTopThumbsUp(db, "discord:123", 5)
 	if err != nil {
 		t.Fatalf("GetTopThumbsUp failed: %v", err)
 	}
@@ -257,7 +284,7 @@ func TestGetTopThumbsUpExcludesZero(t *testing.T) {
 }
 
 func TestGetTopReposters(t *testing.T) {
-	dbPath := setupTestDB(t)
+	db := setupTestDB(t)
 
 	entries := []VideoStatEntry{
 		{Platform: "discord", GroupId: "discord:123", UserId: "u1", Username: "alice", SourceUrl: "https://a.com", BotMessageId: "m1", IsRepost: true, PostedAt: time.Now()},
@@ -266,12 +293,12 @@ func TestGetTopReposters(t *testing.T) {
 		{Platform: "discord", GroupId: "discord:123", UserId: "u3", Username: "carol", SourceUrl: "https://d.com", BotMessageId: "m4", IsRepost: false, PostedAt: time.Now()},
 	}
 	for _, e := range entries {
-		if err := RecordVideoPost(dbPath, e); err != nil {
+		if err := RecordVideoPost(db, e); err != nil {
 			t.Fatalf("RecordVideoPost failed: %v", err)
 		}
 	}
 
-	reposters, err := GetTopReposters(dbPath, "discord:123", 10)
+	reposters, err := GetTopReposters(db, "discord:123", 10)
 	if err != nil {
 		t.Fatalf("GetTopReposters failed: %v", err)
 	}
@@ -280,5 +307,12 @@ func TestGetTopReposters(t *testing.T) {
 	}
 	if reposters[0].Username != "alice" || reposters[0].RepostCount != 2 {
 		t.Errorf("expected alice with 2 reposts first, got %q with %d", reposters[0].Username, reposters[0].RepostCount)
+	}
+}
+
+func TestQueryTopByReactionColumnRejectsUnknownColumn(t *testing.T) {
+	db := setupTestDB(t)
+	if _, err := queryTopByReactionColumn(db, "discord:123", "id; DROP TABLE video_stats;--", 5); err == nil {
+		t.Error("expected error on unknown reaction column, got nil")
 	}
 }


### PR DESCRIPTION
## Summary

- Tracks who posts videos via `/dl` and records stats (poster, URL, timestamp, repost flag) in DuckDB after each successful send
- Tracks 👍/👎 reactions per video on both Telegram (via `MiddlewarePoller` diffing `OldReaction`/`NewReaction` arrays) and Discord (via `MessageReactionAdd`/`Remove` events)
- New `/stats` command shows a per-group leaderboard: top posters, most liked, most disliked, and top reposters
- Schema migration is automatic — existing DBs get the new columns added via `ALTER TABLE IF NOT EXISTS` on first run

## Test plan

- [ ] `/dl <url>` in a group → row appears in `video_stats` table
- [ ] React 👍 to the bot's video message → `thumbs_up_count` increments
- [ ] React 👎 → `thumbs_down_count` increments
- [ ] Change reaction from 👍 to 👎 → counts update correctly (net zero on 👍, +1 on 👎)
- [ ] `/stats` returns leaderboard with all four sections
- [ ] Repost a video → sender appears in "Top reposters" section
- [ ] Existing DB without new columns migrates without data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)