### PR TITLE
feat(telereactions): extract Telegram message_reaction dispatch

### DIFF
--- a/internal/platforms/telegram_api.go
+++ b/internal/platforms/telegram_api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/napuu/gpsp-bot/internal/chain"
 	"github.com/napuu/gpsp-bot/internal/config"
 	"github.com/napuu/gpsp-bot/internal/handlers"
+	"github.com/napuu/gpsp-bot/internal/telereactions"
 	"github.com/napuu/gpsp-bot/pkg/utils"
 
 	tele "gopkg.in/telebot.v4"
@@ -56,44 +57,25 @@ func RunTelegramBot() {
 
 func getTelegramBot(dbPath string) *tele.Bot {
 	inner := &tele.LongPoller{
-		Timeout: 10 * time.Second,
-		AllowedUpdates: []string{
-			"message",
-			"message_reaction",
-		},
+		Timeout:        10 * time.Second,
+		AllowedUpdates: []string{"message"},
 	}
 
-	poller := tele.NewMiddlewarePoller(inner, func(u *tele.Update) bool {
-		if u.MessageReaction != nil {
-			mr := u.MessageReaction
-			groupId := "telegram:" + fmt.Sprint(mr.Chat.ID)
-			botMsgId := fmt.Sprint(mr.MessageID)
-
-			db, err := utils.OpenStatsDB(dbPath)
-			if err != nil {
-				slog.Warn("Failed to open stats DB for reaction", "error", err)
-				return true
-			}
-			defer db.Close()
-
-			// Find added reactions (present in New but not Old)
-			for _, r := range mr.NewReaction {
-				if !containsEmoji(mr.OldReaction, r.Emoji) {
-					if err := utils.UpdateReactionCount(db, "telegram", groupId, botMsgId, r.Emoji, +1); err != nil {
-						slog.Warn("Failed to update Telegram reaction count", "error", err)
-					}
-				}
-			}
-			// Find removed reactions (present in Old but not New)
-			for _, r := range mr.OldReaction {
-				if !containsEmoji(mr.NewReaction, r.Emoji) {
-					if err := utils.UpdateReactionCount(db, "telegram", groupId, botMsgId, r.Emoji, -1); err != nil {
-						slog.Warn("Failed to update Telegram reaction count", "error", err)
-					}
-				}
-			}
+	updateCount := func(e telereactions.Event, delta int) {
+		db, err := utils.OpenStatsDB(dbPath)
+		if err != nil {
+			slog.Warn("Failed to open stats DB for reaction", "error", err)
+			return
 		}
-		return true
+		defer db.Close()
+		groupId := "telegram:" + fmt.Sprint(e.Chat.ID)
+		if err := utils.UpdateReactionCount(db, "telegram", groupId, fmt.Sprint(e.MessageID), e.Emoji, delta); err != nil {
+			slog.Warn("Failed to update Telegram reaction count", "error", err)
+		}
+	}
+	poller := telereactions.Wrap(inner, telereactions.Handlers{
+		OnAdd:    func(e telereactions.Event) { updateCount(e, +1) },
+		OnRemove: func(e telereactions.Event) { updateCount(e, -1) },
 	})
 
 	pref := tele.Settings{
@@ -108,14 +90,4 @@ func getTelegramBot(dbPath string) *tele.Bot {
 	}
 
 	return b
-}
-
-// containsEmoji reports whether emoji e is present in the reaction slice.
-func containsEmoji(reactions []tele.Reaction, emoji string) bool {
-	for _, r := range reactions {
-		if r.Emoji == emoji {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/telereactions/reactions.go
+++ b/internal/telereactions/reactions.go
@@ -1,0 +1,89 @@
+// Package telereactions bridges a gap in gopkg.in/telebot.v4: the library
+// exposes message_reaction update fields but does not dispatch them to a
+// Handle() endpoint. Wrap attaches a filter to a LongPoller that diffs each
+// update's OldReaction/NewReaction and invokes per-emoji add/remove callbacks.
+package telereactions
+
+import (
+	tele "gopkg.in/telebot.v4"
+)
+
+// AllowedUpdate is the Telegram update type this package consumes. Wrap
+// ensures it is present in the inner poller's AllowedUpdates.
+const AllowedUpdate = "message_reaction"
+
+// Event describes a single emoji change on a message. One MessageReaction
+// update with N changed emoji becomes N events.
+type Event struct {
+	Chat      *tele.Chat
+	MessageID int
+	User      *tele.User
+	ActorChat *tele.Chat
+	Emoji     string
+}
+
+// Handlers holds the callbacks Wrap invokes. Either field may be nil.
+type Handlers struct {
+	OnAdd    func(Event)
+	OnRemove func(Event)
+}
+
+// Wrap returns a MiddlewarePoller that diffs message_reaction updates and
+// fires Handlers for each changed emoji. It mutates inner.AllowedUpdates to
+// include "message_reaction" if missing.
+func Wrap(inner *tele.LongPoller, h Handlers) *tele.MiddlewarePoller {
+	ensureAllowed(inner)
+	return tele.NewMiddlewarePoller(inner, func(u *tele.Update) bool {
+		dispatch(u, h)
+		return true
+	})
+}
+
+func ensureAllowed(p *tele.LongPoller) {
+	for _, u := range p.AllowedUpdates {
+		if u == AllowedUpdate {
+			return
+		}
+	}
+	p.AllowedUpdates = append(p.AllowedUpdates, AllowedUpdate)
+}
+
+func dispatch(u *tele.Update, h Handlers) {
+	if u == nil || u.MessageReaction == nil {
+		return
+	}
+	mr := u.MessageReaction
+	base := Event{
+		Chat:      mr.Chat,
+		MessageID: mr.MessageID,
+		User:      mr.User,
+		ActorChat: mr.ActorChat,
+	}
+	if h.OnAdd != nil {
+		for _, r := range mr.NewReaction {
+			if !containsEmoji(mr.OldReaction, r.Emoji) {
+				e := base
+				e.Emoji = r.Emoji
+				h.OnAdd(e)
+			}
+		}
+	}
+	if h.OnRemove != nil {
+		for _, r := range mr.OldReaction {
+			if !containsEmoji(mr.NewReaction, r.Emoji) {
+				e := base
+				e.Emoji = r.Emoji
+				h.OnRemove(e)
+			}
+		}
+	}
+}
+
+func containsEmoji(rs []tele.Reaction, emoji string) bool {
+	for _, r := range rs {
+		if r.Emoji == emoji {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/telereactions/reactions_test.go
+++ b/internal/telereactions/reactions_test.go
@@ -1,0 +1,103 @@
+package telereactions
+
+import (
+	"reflect"
+	"testing"
+
+	tele "gopkg.in/telebot.v4"
+)
+
+func emoji(s string) tele.Reaction {
+	return tele.Reaction{Type: tele.ReactionTypeEmoji, Emoji: s}
+}
+
+func TestDispatch_AddRemoveDiff(t *testing.T) {
+	var added, removed []string
+	h := Handlers{
+		OnAdd:    func(e Event) { added = append(added, e.Emoji) },
+		OnRemove: func(e Event) { removed = append(removed, e.Emoji) },
+	}
+
+	u := &tele.Update{
+		MessageReaction: &tele.MessageReaction{
+			Chat:        &tele.Chat{ID: -1001234567890},
+			MessageID:   42,
+			OldReaction: []tele.Reaction{emoji("👍"), emoji("❤")},
+			NewReaction: []tele.Reaction{emoji("👍"), emoji("🔥")},
+		},
+	}
+	dispatch(u, h)
+
+	if !reflect.DeepEqual(added, []string{"🔥"}) {
+		t.Errorf("added = %v, want [🔥]", added)
+	}
+	if !reflect.DeepEqual(removed, []string{"❤"}) {
+		t.Errorf("removed = %v, want [❤]", removed)
+	}
+}
+
+func TestDispatch_NilHandlersDoNotPanic(t *testing.T) {
+	u := &tele.Update{
+		MessageReaction: &tele.MessageReaction{
+			Chat:        &tele.Chat{ID: 1},
+			NewReaction: []tele.Reaction{emoji("👍")},
+		},
+	}
+	dispatch(u, Handlers{}) // OnAdd + OnRemove both nil
+}
+
+func TestDispatch_IgnoresNonReactionUpdates(t *testing.T) {
+	called := false
+	h := Handlers{OnAdd: func(Event) { called = true }}
+	dispatch(&tele.Update{}, h)
+	dispatch(nil, h)
+	if called {
+		t.Error("OnAdd fired for update without MessageReaction")
+	}
+}
+
+func TestDispatch_CarriesChatAndMessageID(t *testing.T) {
+	var got Event
+	h := Handlers{OnAdd: func(e Event) { got = e }}
+	u := &tele.Update{
+		MessageReaction: &tele.MessageReaction{
+			Chat:        &tele.Chat{ID: -100999},
+			MessageID:   777,
+			User:        &tele.User{ID: 55},
+			NewReaction: []tele.Reaction{emoji("👎")},
+		},
+	}
+	dispatch(u, h)
+
+	if got.Chat.ID != -100999 || got.MessageID != 777 || got.User.ID != 55 || got.Emoji != "👎" {
+		t.Errorf("event = %+v", got)
+	}
+}
+
+func TestEnsureAllowed_AppendsWhenMissing(t *testing.T) {
+	p := &tele.LongPoller{AllowedUpdates: []string{"message"}}
+	ensureAllowed(p)
+	want := []string{"message", "message_reaction"}
+	if !reflect.DeepEqual(p.AllowedUpdates, want) {
+		t.Errorf("AllowedUpdates = %v, want %v", p.AllowedUpdates, want)
+	}
+}
+
+func TestEnsureAllowed_NoDuplicate(t *testing.T) {
+	p := &tele.LongPoller{AllowedUpdates: []string{"message", "message_reaction"}}
+	ensureAllowed(p)
+	if len(p.AllowedUpdates) != 2 {
+		t.Errorf("AllowedUpdates = %v, expected no duplicate", p.AllowedUpdates)
+	}
+}
+
+func TestWrap_ReturnsMiddlewarePoller(t *testing.T) {
+	inner := &tele.LongPoller{}
+	mp := Wrap(inner, Handlers{})
+	if mp == nil || mp.Poller != inner {
+		t.Error("Wrap did not return a MiddlewarePoller wrapping the inner poller")
+	}
+	if len(inner.AllowedUpdates) == 0 || inner.AllowedUpdates[0] != "message_reaction" {
+		t.Errorf("Wrap did not inject message_reaction; got %v", inner.AllowedUpdates)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/telereactions` package that diffs `OldReaction`/`NewReaction` on `message_reaction` updates and invokes per-emoji `OnAdd`/`OnRemove` callbacks
- `telegram_api.go` consumes it instead of inlining a `MiddlewarePoller` filter, shrinking the bot setup by ~35 lines
- `Wrap` auto-injects `"message_reaction"` into the inner poller's `AllowedUpdates` so callers cannot forget it
- Motivation: telebot v4 exposes `MessageReaction` update fields but has no `OnMessageReaction` endpoint, so the extraction gives us one reusable place for that gap

## Test plan
- [x] `go test ./internal/telereactions/...` — unit tests cover the diff, nil-handler safety, non-reaction updates, event payload, and `AllowedUpdates` injection
- [x] `go build ./...`
- [x] Smoke-test in a Telegram supergroup where the bot is admin: react/unreact on a `/dl` post and confirm `thumbs_up_count` / `thumbs_down_count` move

🤖 Generated with [Claude Code](https://claude.com/claude-code)