### PR TITLE
feat(stats): suppress link previews on /stats response

### DIFF
--- a/internal/handlers/context.go
+++ b/internal/handlers/context.go
@@ -63,6 +63,10 @@ type Context struct {
 	imageReplyToId            string
 	action                    Action
 	url                       string
+	// When true, suppress link previews / embeds on the outgoing text response.
+	// Used by /stats where URLs are informational and auto-expanding them would
+	// dominate the message.
+	disableWebPreview bool
 
 	doneTyping         chan struct{}
 	gotDubz            bool

--- a/internal/handlers/stats_handler.go
+++ b/internal/handlers/stats_handler.go
@@ -18,6 +18,7 @@ func (h *StatsHandler) Execute(m *Context) {
 	slog.Debug("Entering StatsHandler")
 
 	if m.action == Stats {
+		m.disableWebPreview = true
 		cfg := config.FromEnv()
 		dbPath := filepath.Join(cfg.REPOST_DB_DIR, statsDBFileName)
 

--- a/internal/handlers/text_response_handler.go
+++ b/internal/handlers/text_response_handler.go
@@ -36,27 +36,33 @@ func (r *TextResponseHandler) Execute(m *Context) {
 
 	switch m.Service {
 	case Telegram:
+		opts := &tele.SendOptions{DisableWebPagePreview: m.disableWebPreview}
 		if m.shouldReplyToMessage {
 			chatId := tele.ChatID(utils.S2I(m.chatId))
-			message := &tele.Message{
+			opts.ReplyTo = &tele.Message{
 				Chat: &tele.Chat{ID: int64(utils.S2I(m.chatId))},
 				ID:   utils.S2I(m.replyToId),
 			}
-			m.Telebot.Send(chatId, m.textResponse, &tele.SendOptions{ReplyTo: message})
+			m.Telebot.Send(chatId, m.textResponse, opts)
 		} else if m.textResponse != "" {
-			m.TelebotContext.Send(m.textResponse)
+			m.TelebotContext.Send(m.textResponse, opts)
 		}
 
 	case Discord:
+		if m.textResponse == "" {
+			break
+		}
+		send := &discordgo.MessageSend{Content: m.textResponse}
+		if m.disableWebPreview {
+			send.Flags = discordgo.MessageFlagsSuppressEmbeds
+		}
 		if m.shouldReplyToMessage {
-			message := &discordgo.MessageReference{
+			send.Reference = &discordgo.MessageReference{
 				ChannelID: m.chatId,
 				MessageID: m.replyToId,
 			}
-			m.DiscordSession.ChannelMessageSendReply(m.chatId, m.textResponse, message)
-		} else if m.textResponse != "" {
-			m.DiscordSession.ChannelMessageSend(m.chatId, m.textResponse)
 		}
+		m.DiscordSession.ChannelMessageSendComplex(m.chatId, send)
 	}
 
 	r.next.Execute(m)


### PR DESCRIPTION
## Summary
- `/stats` output lists source URLs alongside reaction counts; Telegram was auto-previewing the first URL and Discord was auto-embedding them all, which drowned out the leaderboard itself
- Add `disableWebPreview` flag on `Context`, set it in `StatsHandler`, and honor it in `TextResponseHandler`
- Telegram: `tele.SendOptions{DisableWebPagePreview: true}` on both reply and non-reply paths
- Discord: switch `ChannelMessageSend`/`ChannelMessageSendReply` to a single `ChannelMessageSendComplex` call that sets `MessageFlagsSuppressEmbeds` when the flag is on

🤖 Generated with [Claude Code](https://claude.com/claude-code)