### PR TITLE
feat: use direct platform deep links for stats URLs

### DIFF
--- a/internal/handlers/context.go
+++ b/internal/handlers/context.go
@@ -58,6 +58,8 @@ type Context struct {
 	shouldReplyToMessage bool
 	isReply              bool
 	chatId               string
+	chatUsername         string
+	guildId              string
 	// Image-specific reply fields (used when repost image needs different reply target than video)
 	imageShouldReplyToMessage bool
 	imageReplyToId            string

--- a/internal/handlers/on_text_handler.go
+++ b/internal/handlers/on_text_handler.go
@@ -22,6 +22,7 @@ func (mp *OnTextHandler) Execute(m *Context) {
 			m.id = strconv.Itoa(c.Message().ID)
 			m.isReply = c.Message().IsReply()
 			m.chatId = strconv.Itoa(int(c.Chat().ID))
+			m.chatUsername = c.Chat().Username
 
 			if c.Message().IsReply() {
 				m.replyToId = fmt.Sprint(c.Message().ReplyTo.ID)
@@ -46,6 +47,7 @@ func (mp *OnTextHandler) Execute(m *Context) {
 				m.shouldReplyToMessage = true
 			}
 			m.chatId = message.ChannelID
+			m.guildId = message.GuildID
 
 			if message.Author != nil {
 				m.posterUserId = message.Author.ID

--- a/internal/handlers/stats_handler.go
+++ b/internal/handlers/stats_handler.go
@@ -124,18 +124,20 @@ func appendReactionSection(m *Context, sb *strings.Builder, videos []utils.React
 		if v.BotMessageId != "" {
 			if m.Service == Telegram {
 				if m.chatUsername != "" {
+					// Public Telegram chats can be linked directly by username.
 					url = fmt.Sprintf("https://t.me/%s/%s", m.chatUsername, v.BotMessageId)
 				} else if strings.HasPrefix(m.chatId, "-100") {
+					// Telegram supergroups/channels often only expose the internal -100 ID.
 					url = fmt.Sprintf("https://t.me/c/%s/%s", strings.TrimPrefix(m.chatId, "-100"), v.BotMessageId)
-				} else {
+				} else if strings.HasPrefix(m.chatId, "-") {
+					// Other negative Telegram IDs are not guaranteed to map to a valid public link.
 					url = fmt.Sprintf("https://t.me/c/%s/%s", strings.TrimPrefix(m.chatId, "-"), v.BotMessageId)
 				}
 			} else if m.Service == Discord {
-				guildId := m.guildId
-				if guildId == "" {
-					guildId = "@me"
+				if m.guildId != "" {
+					// Discord channel deep links need a guild ID; without it the URL would be broken.
+					url = fmt.Sprintf("https://discord.com/channels/%s/%s/%s", m.guildId, m.chatId, v.BotMessageId)
 				}
-				url = fmt.Sprintf("https://discord.com/channels/%s/%s/%s", guildId, m.chatId, v.BotMessageId)
 			}
 		}
 

--- a/internal/handlers/stats_handler.go
+++ b/internal/handlers/stats_handler.go
@@ -38,7 +38,7 @@ func (h *StatsHandler) Execute(m *Context) {
 		db, err := utils.OpenStatsDB(dbPath)
 		if err != nil {
 			slog.Warn("Failed to open stats DB", "error", err)
-			m.textResponse = buildStatsText(nil, err, nil, err, nil, err, nil, err)
+			m.textResponse = buildStatsText(m, nil, err, nil, err, nil, err, nil, err)
 			h.next.Execute(m)
 			return
 		}
@@ -49,7 +49,7 @@ func (h *StatsHandler) Execute(m *Context) {
 		thumbsDown, thumbsDownErr := utils.GetTopThumbsDown(db, groupId, 5)
 		reposters, repostersErr := utils.GetTopReposters(db, groupId, 5)
 
-		m.textResponse = buildStatsText(posters, postersErr, thumbsUp, thumbsUpErr, thumbsDown, thumbsDownErr, reposters, repostersErr)
+		m.textResponse = buildStatsText(m, posters, postersErr, thumbsUp, thumbsUpErr, thumbsDown, thumbsDownErr, reposters, repostersErr)
 	}
 
 	h.next.Execute(m)
@@ -60,6 +60,7 @@ func (h *StatsHandler) SetNext(next ContextHandler) {
 }
 
 func buildStatsText(
+	m *Context,
 	posters []utils.PosterStat, postersErr error,
 	thumbsUp []utils.ReactionStat, thumbsUpErr error,
 	thumbsDown []utils.ReactionStat, thumbsDownErr error,
@@ -71,10 +72,10 @@ func buildStatsText(
 	appendPosterSection(&sb, posters, postersErr)
 
 	sb.WriteString("\n👍 Most liked:\n")
-	appendReactionSection(&sb, thumbsUp, thumbsUpErr)
+	appendReactionSection(m, &sb, thumbsUp, thumbsUpErr)
 
 	sb.WriteString("\n👎 Most disliked:\n")
-	appendReactionSection(&sb, thumbsDown, thumbsDownErr)
+	appendReactionSection(m, &sb, thumbsDown, thumbsDownErr)
 
 	sb.WriteString("\nTop reposters:\n")
 	appendReposterSection(&sb, reposters, repostersErr)
@@ -104,7 +105,7 @@ func appendPosterSection(sb *strings.Builder, posters []utils.PosterStat, err er
 	}
 }
 
-func appendReactionSection(sb *strings.Builder, videos []utils.ReactionStat, err error) {
+func appendReactionSection(m *Context, sb *strings.Builder, videos []utils.ReactionStat, err error) {
 	if err != nil {
 		sb.WriteString("(error fetching data)\n")
 		return
@@ -118,7 +119,27 @@ func appendReactionSection(sb *strings.Builder, videos []utils.ReactionStat, err
 		if name == "" {
 			name = "unknown"
 		}
-		sb.WriteString(fmt.Sprintf("%d. %s — %d (%s)\n", i+1, name, v.ReactionCount, v.SourceUrl))
+		
+		url := v.SourceUrl
+		if v.BotMessageId != "" {
+			if m.Service == Telegram {
+				if m.chatUsername != "" {
+					url = fmt.Sprintf("https://t.me/%s/%s", m.chatUsername, v.BotMessageId)
+				} else if strings.HasPrefix(m.chatId, "-100") {
+					url = fmt.Sprintf("https://t.me/c/%s/%s", strings.TrimPrefix(m.chatId, "-100"), v.BotMessageId)
+				} else {
+					url = fmt.Sprintf("https://t.me/c/%s/%s", strings.TrimPrefix(m.chatId, "-"), v.BotMessageId)
+				}
+			} else if m.Service == Discord {
+				guildId := m.guildId
+				if guildId == "" {
+					guildId = "@me"
+				}
+				url = fmt.Sprintf("https://discord.com/channels/%s/%s/%s", guildId, m.chatId, v.BotMessageId)
+			}
+		}
+
+		sb.WriteString(fmt.Sprintf("%d. %s — %d (%s)\n", i+1, name, v.ReactionCount, url))
 	}
 }
 

--- a/internal/handlers/stats_handler_test.go
+++ b/internal/handlers/stats_handler_test.go
@@ -136,6 +136,28 @@ func TestBuildStatsTextEmpty(t *testing.T) {
 	}
 }
 
+func TestBuildStatsTextKeepsSourceUrlWhenDeepLinkCannotBeBuilt(t *testing.T) {
+	ctx := &Context{Service: Discord, chatId: "999", action: Stats}
+	thumbsUp := []utils.ReactionStat{{BotMessageId: "m1", Username: "alice", SourceUrl: "https://example.com/original", ReactionCount: 7}}
+
+	result := buildStatsText(ctx, nil, nil, thumbsUp, nil, nil, nil, nil, nil)
+
+	if !strings.Contains(result, "https://example.com/original") {
+		t.Errorf("expected result to keep source url when guild id is missing, got: %q", result)
+	}
+}
+
+func TestBuildStatsTextUsesTelegramChannelLinkOnlyForValidChatIds(t *testing.T) {
+	ctx := &Context{Service: Telegram, chatId: "12345", action: Stats}
+	thumbsUp := []utils.ReactionStat{{BotMessageId: "m1", Username: "alice", SourceUrl: "https://example.com/original", ReactionCount: 7}}
+
+	result := buildStatsText(ctx, nil, nil, thumbsUp, nil, nil, nil, nil, nil)
+
+	if !strings.Contains(result, "https://example.com/original") {
+		t.Errorf("expected result to keep source url for non-channel telegram chat, got: %q", result)
+	}
+}
+
 func TestBuildStatsTextSingularPlural(t *testing.T) {
 	ctx := &Context{Service: Discord, chatId: "999", action: Stats}
 	posters := []utils.PosterStat{{UserId: "u1", Username: "alice", PostCount: 1}}

--- a/internal/handlers/stats_handler_test.go
+++ b/internal/handlers/stats_handler_test.go
@@ -86,16 +86,23 @@ func TestBuildStatsTextWithData(t *testing.T) {
 		{UserId: "u2", Username: "bob", PostCount: 2},
 	}
 	thumbsUp := []utils.ReactionStat{
-		{BotMessageId: "m1", Username: "alice", SourceUrl: "https://example.com/v1", ReactionCount: 7, PostedAt: time.Now()},
+		{BotMessageId: "m1", Username: "alice", SourceUrl: "https://discord.com/channels/123/999/m1", ReactionCount: 7, PostedAt: time.Now()},
 	}
 	thumbsDown := []utils.ReactionStat{
-		{BotMessageId: "m2", Username: "bob", SourceUrl: "https://example.com/v2", ReactionCount: 3, PostedAt: time.Now()},
+		{BotMessageId: "m2", Username: "bob", SourceUrl: "https://discord.com/channels/123/999/m2", ReactionCount: 3, PostedAt: time.Now()},
 	}
 	reposters := []utils.RepostStat{
 		{UserId: "u2", Username: "bob", RepostCount: 4},
 	}
 
-	result := buildStatsText(posters, nil, thumbsUp, nil, thumbsDown, nil, reposters, nil)
+	ctx := &Context{
+		Service: Discord,
+		chatId:  "999",
+		guildId: "123",
+		action:  Stats,
+	}
+
+	result := buildStatsText(ctx, posters, nil, thumbsUp, nil, thumbsDown, nil, reposters, nil)
 
 	if !strings.Contains(result, "alice") {
 		t.Errorf("expected result to contain 'alice', got: %q", result)
@@ -115,7 +122,8 @@ func TestBuildStatsTextWithData(t *testing.T) {
 }
 
 func TestBuildStatsTextEmpty(t *testing.T) {
-	result := buildStatsText(nil, nil, nil, nil, nil, nil, nil, nil)
+	ctx := &Context{Service: Discord, chatId: "999", action: Stats}
+	result := buildStatsText(ctx, nil, nil, nil, nil, nil, nil, nil, nil)
 
 	if !strings.Contains(result, "No videos posted yet") {
 		t.Errorf("expected empty-state message for posters, got: %q", result)
@@ -129,10 +137,11 @@ func TestBuildStatsTextEmpty(t *testing.T) {
 }
 
 func TestBuildStatsTextSingularPlural(t *testing.T) {
+	ctx := &Context{Service: Discord, chatId: "999", action: Stats}
 	posters := []utils.PosterStat{{UserId: "u1", Username: "alice", PostCount: 1}}
 	reposters := []utils.RepostStat{{UserId: "u2", Username: "bob", RepostCount: 1}}
 
-	result := buildStatsText(posters, nil, nil, nil, nil, nil, reposters, nil)
+	result := buildStatsText(ctx, posters, nil, nil, nil, nil, nil, reposters, nil)
 
 	if strings.Contains(result, "1 videos") {
 		t.Errorf("expected singular '1 video', got: %q", result)


### PR DESCRIPTION
## Summary
* Modifies `buildStatsText` to generate platform-specific URLs for top liked and disliked stats.
* Adds `chatUsername` and `guildId` to `Context` to support building these deep links for Telegram and Discord respectively.
* Updates `stats_handler_test.go` to mock the context with these new parameters.